### PR TITLE
make config file loading relative to cwd

### DIFF
--- a/feature_server/run.py
+++ b/feature_server/run.py
@@ -64,8 +64,8 @@ def main():
     arg_parser = argparse.ArgumentParser(prog=cfg.pkg_name,
                                          description='%s is an open-source Python server implementation for the voxel-based game "Ace of Spades".' % cfg.pkg_name)
 
-    arg_parser.add_argument('-c', '--config-file', default='config.json',
-            help='specify the config file (relative to config dir if relative path) - default is "config.json"')
+    arg_parser.add_argument('-c', '--config-file', default=None,
+            help='specify the config file - default is "config.json" in the config dir')
     arg_parser.add_argument('-j', '--json-parameters',
             help='add extra json parameters (overrides the ones present in the config file)')
     arg_parser.add_argument('-d', '--config-dir', default=cfg.config_dir,
@@ -77,7 +77,12 @@ def main():
 
     # populate the global config with values from args
     cfg.config_dir = args.config_dir
-    cfg.config_file = args.config_file
+
+    if args.config_file is None:
+        cfg.config_file = os.path.join(cfg.config_dir, 'config.json')
+    else:
+        cfg.config_file = args.config_file
+
     cfg.json_parameters = args.json_parameters
 
     run = True

--- a/feature_server/server.py
+++ b/feature_server/server.py
@@ -43,13 +43,6 @@ DEFAULT_PASSWORDS = {
 
 PORT = 32887
 
-def choose_path(base, top):
-    "helper function to choose the right path/file for the config, etc."
-    if not os.path.isabs(top):
-        return os.path.join(base, top)
-    return top
-
-
 def get_git_rev():
     if not os.path.exists(".git"):
         return 'snapshot'
@@ -628,8 +621,10 @@ class FeatureProtocol(ServerProtocol):
         if ban_subscribe.get('enabled', True):
             import bansubscribe
             self.ban_manager = bansubscribe.BanManager(self, ban_subscribe)
-        # logfile location in resource dir if not abs path given
-        logfile = choose_path(cfg.config_dir, config.get('logfile', ''))
+        # logfile path relative to config dir if not abs path
+        logfile = config.get('logfile', '')
+        if not os.path.isabs(logfile):
+            logfile = os.path.join(cfg.config_dir, logfile)
         if logfile.strip(): # catches empty filename
             if config.get('rotate_daily', False):
                 create_filename_path(logfile)
@@ -1015,10 +1010,6 @@ def run():
     # add our package to path too so scripts can import `feature_server/`
     # a better way instead of abs path?
     sys.path.insert(1, os.path.dirname(os.path.abspath(__file__)))
-
-    # fix the path for the config file - handles differering directories and relative or absolute paths
-    config_file = choose_path(cfg.config_dir, cfg.config_file)
-    cfg.config_file = config_file
 
     try:
         with open(cfg.config_file, 'rb') as f:


### PR DESCRIPTION
As in the title. This makes it more intuitive when specifying the config file location on the command line, and is consistent with how the config dir argument works.