### PR TITLE
Tidy server.py + better script loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,9 +28,9 @@ dist/
 .eggs
 
 # config/userdata
-config/maps/*.txtc
-config/logs/*
-config/data/*
+feature_server/config/maps/*.txtc
+feature_server/config/logs/*
+feature_server/config/data/*
 
 # py2exe
 py2exe/dist/

--- a/feature_server/cfg.py
+++ b/feature_server/cfg.py
@@ -3,7 +3,9 @@
 # similar to http://effbot.org/pyfaq/how-do-i-share-global-variables-across-modules.htm
 
 import os
+import sys
 
+server_version = '%s - %s' % (sys.platform, '0.0.1a')
 config = {}
 pkg_name = "piqueserver"
 config_file = 'config.json'

--- a/feature_server/config/scripts/afk.py
+++ b/feature_server/config/scripts/afk.py
@@ -8,7 +8,7 @@ from math import ceil
 from operator import attrgetter
 from twisted.internet import reactor
 from pyspades.common import prettify_timespan
-from commands import name, get_player, add, admin
+from piqueserver.commands import name, get_player, add, admin
 
 S_AFK_CHECK = '{player} has been inactive for {time}'
 S_NO_PLAYERS_INACTIVE = 'No players or connections inactive for {time}'

--- a/feature_server/config/scripts/aimblock.py
+++ b/feature_server/config/scripts/aimblock.py
@@ -14,7 +14,7 @@
 # - Ben "GreaseMonkey" Russell
 
 from twisted.internet import reactor
-import commands
+import piqueserver.commands
 
 # disable if you don't want to see all the jerk information
 AIMBLOCK_SPAM = False

--- a/feature_server/config/scripts/aimbot2.py
+++ b/feature_server/config/scripts/aimbot2.py
@@ -1,7 +1,7 @@
 from twisted.internet.task import LoopingCall
 from pyspades.constants import *
 from math import sqrt, cos, acos, pi, tan
-from commands import add, admin, get_player
+from piqueserver.commands import add, admin, get_player
 from twisted.internet import reactor
 import re
 

--- a/feature_server/config/scripts/airstrike.py
+++ b/feature_server/config/scripts/airstrike.py
@@ -12,7 +12,7 @@ from pyspades.common import coordinates, to_coordinates, Vertex3
 from pyspades.collision import distance_3d_vector
 from pyspades.world import Grenade
 from pyspades.constants import UPDATE_FREQUENCY
-from commands import alias, add
+from piqueserver.commands import alias, add
 
 SCORE_REQUIREMENT = 0
 STREAK_REQUIREMENT = 8

--- a/feature_server/config/scripts/arena.py
+++ b/feature_server/config/scripts/arena.py
@@ -35,7 +35,7 @@ from pyspades import world
 from pyspades.constants import *
 from twisted.internet import reactor
 from twisted.internet.task import LoopingCall
-from commands import add, admin
+from piqueserver.commands import add, admin
 
 # If ALWAYS_ENABLED is False, then the 'arena' key must be set to True in
 # the 'extensions' dictionary in the map metadata

--- a/feature_server/config/scripts/badmin.py
+++ b/feature_server/config/scripts/badmin.py
@@ -6,7 +6,7 @@ from twisted.internet import reactor
 from pyspades.common import prettify_timespan
 from pyspades.constants import *
 from pyspades.collision import distance_3d_vector
-from commands import add, admin, get_player
+from piqueserver.commands import add, admin, get_player
 import re
 
 BADMIN_VERSION = 9

--- a/feature_server/config/scripts/blockinfo.py
+++ b/feature_server/config/scripts/blockinfo.py
@@ -7,7 +7,7 @@ Maintainer: hompy
 from twisted.internet.reactor import seconds
 from pyspades.collision import distance_3d_vector
 from pyspades.common import prettify_timespan
-from commands import add, admin, name, get_player, alias
+from piqueserver.commands import add, admin, name, get_player, alias
 
 # "blockinfo" must be AFTER "votekick" in the config.txt script list
 GRIEFCHECK_ON_VOTEKICK = True

--- a/feature_server/config/scripts/commandhelp.py
+++ b/feature_server/config/scripts/commandhelp.py
@@ -6,7 +6,7 @@ See the file license.txt or http://opensource.org/licenses/MIT for copying permi
 Lists all commands available to you (permission based).
 """
 
-from commands import add, admin, commands as cmdlist, aliases as aliaslist
+from piqueserver.commands import add, admin, commands as cmdlist, aliases as aliaslist
 import fnmatch
 
 def commands(connection, value = None):

--- a/feature_server/config/scripts/daycycle.py
+++ b/feature_server/config/scripts/daycycle.py
@@ -5,7 +5,7 @@ Maintainer: hompy
 """
 
 from twisted.internet.task import LoopingCall
-from commands import name, admin, add
+from piqueserver.commands import name, admin, add
 
 S_NO_RIGHTS = 'No administrator rights!'
 S_TIME_OF_DAY = 'Time of day: {hours:02d}:{minutes:02d}'

--- a/feature_server/config/scripts/demolitionman.py
+++ b/feature_server/config/scripts/demolitionman.py
@@ -6,7 +6,7 @@ See the file license.txt or http://opensource.org/licenses/MIT for copying permi
 Restocks the user when reloading / throwing a nade.
 """
 
-from commands import add, admin
+from piqueserver.commands import add, admin
 
 DEMOLITION_ENABLED_AT_ROUND_START = False
 

--- a/feature_server/config/scripts/disco.py
+++ b/feature_server/config/scripts/disco.py
@@ -8,7 +8,7 @@ from twisted.internet.task import LoopingCall
 from twisted.internet.reactor import callLater
 import random
 
-import commands
+from piqueserver import commands
 
 DISCO_ON_GAME_END = True
 # Time is in seconds

--- a/feature_server/config/scripts/dynfog.py
+++ b/feature_server/config/scripts/dynfog.py
@@ -1,4 +1,4 @@
-import commands
+import piqueserver.commands
 
 def apply_script(protocol, connection, config):
     class FogProtocol(protocol):

--- a/feature_server/config/scripts/grownade.py
+++ b/feature_server/config/scripts/grownade.py
@@ -49,7 +49,7 @@ from twisted.internet.task import LoopingCall
 from pyspades.server import block_action, block_line, set_color
 from pyspades.common import make_color
 from pyspades.constants import *
-from commands import add, admin, name, get_player
+from piqueserver.commands import add, admin, name, get_player
 
 FLYING_MODELS = False # if False grenades exploding in midair will be ignored
 GROW_ON_WATER = False # if False grenades exploding in water will do nothing

--- a/feature_server/config/scripts/mapmakingtools.py
+++ b/feature_server/config/scripts/mapmakingtools.py
@@ -1,4 +1,4 @@
-from commands import add, admin
+from piqueserver.commands import add, admin
 from pyspades.contained import BlockAction, SetColor
 from pyspades.constants import *
 from math import *

--- a/feature_server/config/scripts/markers.py
+++ b/feature_server/config/scripts/markers.py
@@ -36,7 +36,7 @@ from pyspades.world import cube_line
 from pyspades.server import block_action, block_line, set_color, chat_message
 from pyspades.common import make_color, to_coordinates
 from pyspades.constants import *
-from commands import add, admin, get_player, name
+from piqueserver.commands import add, admin, get_player, name
 
 SHADOW_INTEL = True # if True, shows where the intel used to be before taken
 REVEAL_ENEMIES = True # if True, mimics old intel reveal behavior when captured

--- a/feature_server/config/scripts/match.py
+++ b/feature_server/config/scripts/match.py
@@ -9,7 +9,7 @@ from twisted.internet import reactor
 from twisted.internet.task import LoopingCall
 
 import json
-import commands
+from piqueserver import commands
 
 @commands.admin
 @commands.name('timer')

--- a/feature_server/config/scripts/medkit.py
+++ b/feature_server/config/scripts/medkit.py
@@ -5,7 +5,7 @@ Author: Booboorocks998
 Maintainer: mat^2
 """
 
-import commands
+import piqueserver.commands
 from pyspades.constants import *
 
 @commands.alias('m')

--- a/feature_server/config/scripts/minefield.py
+++ b/feature_server/config/scripts/minefield.py
@@ -40,7 +40,7 @@ from pyspades.collision import collision_3d
 from pyspades.constants import DESTROY_BLOCK, SPADE_DESTROY, BUILD_BLOCK
 from pyspades.contained import BlockAction, SetColor
 from twisted.internet.reactor import callLater
-from commands import add, admin
+from piqueserver.commands import add, admin
 from random import choice
 
 KILL_MESSAGES = [

--- a/feature_server/config/scripts/onectf.py
+++ b/feature_server/config/scripts/onectf.py
@@ -1,5 +1,5 @@
 from pyspades.constants import *
-from commands import add, admin
+from piqueserver.commands import add, admin
 from pyspades.collision import vector_collision
 
 FLAG_SPAWN_POS = (256, 256)

--- a/feature_server/config/scripts/paint.py
+++ b/feature_server/config/scripts/paint.py
@@ -11,7 +11,7 @@ Maintainer: hompy
 from pyspades.server import block_action
 from pyspades.common import Vertex3
 from pyspades.constants import *
-from commands import add, admin, get_player
+from piqueserver.commands import add, admin, get_player
 
 PAINT_RAY_LENGTH = 32.0
 

--- a/feature_server/config/scripts/passreload.py
+++ b/feature_server/config/scripts/passreload.py
@@ -1,8 +1,8 @@
 # passreload.py
 # written by Danke
 
-import commands
-from commands import add, admin
+from piqueserver import commands
+from piqueserver.commands import add, admin
 import json
 
 @admin

--- a/feature_server/config/scripts/platform.py
+++ b/feature_server/config/scripts/platform.py
@@ -189,8 +189,8 @@ from pyspades.collision import collision_3d
 from pyspades.common import make_color
 from pyspades.types import MultikeyDict
 from pyspades.constants import *
-from commands import add, admin, name, alias, join_arguments
-from map import DEFAULT_LOAD_DIR
+from piqueserver.commands import add, admin, name, alias, join_arguments
+from piqueserver.map import DEFAULT_LOAD_DIR
 
 SAVE_ON_MAP_CHANGE = True
 AUTOSAVE_EVERY = 0.0 # minutes, 0 = disabled

--- a/feature_server/config/scripts/protect.py
+++ b/feature_server/config/scripts/protect.py
@@ -4,7 +4,7 @@ Protects areas against block destroying/building.
 Maintainer: hompy
 """
 
-from commands import add, admin
+from piqueserver.commands import add, admin
 from pyspades.common import coordinates
 
 @admin

--- a/feature_server/config/scripts/rapid.py
+++ b/feature_server/config/scripts/rapid.py
@@ -17,7 +17,7 @@ from twisted.internet.reactor import callLater
 from twisted.internet.task import LoopingCall
 from pyspades.server import set_tool
 from pyspades.constants import *
-from commands import add, admin, get_player, name
+from piqueserver.commands import add, admin, get_player, name
 
 ALWAYS_RAPID = False
 RAPID_INTERVAL = 0.08

--- a/feature_server/config/scripts/ratio.py
+++ b/feature_server/config/scripts/ratio.py
@@ -5,7 +5,7 @@ Author: TheGrandmaster
 Maintainer: mat^2
 """
 
-from commands import get_player, add
+from piqueserver.commands import get_player, add
 
 # "ratio" must be AFTER "votekick" in the config.txt script list
 RATIO_ON_VOTEKICK = True

--- a/feature_server/config/scripts/rollback.py
+++ b/feature_server/config/scripts/rollback.py
@@ -9,8 +9,8 @@ from pyspades.vxl import VXLData
 from pyspades.contained import BlockAction, SetColor
 from pyspades.constants import *
 from pyspades.common import coordinates, make_color
-from map import Map, MapNotFound, check_rotation
-from commands import add, admin
+from piqueserver.map import Map, MapNotFound, check_rotation
+from piqueserver.commands import add, admin
 import time
 import operator
 

--- a/feature_server/config/scripts/runningman.py
+++ b/feature_server/config/scripts/runningman.py
@@ -19,7 +19,7 @@ from pyspades.server import grenade_packet
 from pyspades.collision import distance_3d_vector
 from pyspades.constants import *
 from pyspades.common import Vertex3
-from commands import add, admin, get_player, name
+from piqueserver.commands import add, admin, get_player, name
 
 ENABLED_AT_START = False
 

--- a/feature_server/config/scripts/squad.py
+++ b/feature_server/config/scripts/squad.py
@@ -4,8 +4,8 @@ BF-like squad system.
 Maintainer: Triplefox
 """
 
-from commands import add, rights, admin, name, get_player
-import commands
+from piqueserver.commands import add, rights, admin, name, get_player
+from piqueserver import commands
 import random
 
 SQUAD_NAMES = set([

--- a/feature_server/config/scripts/stats.py
+++ b/feature_server/config/scripts/stats.py
@@ -7,7 +7,7 @@ Maintainer: mat^2
 
 from statistics import DEFAULT_PORT, connect_statistics
 
-import commands
+from piqueserver import commands
 
 def sitelogin(connection, name, password):
     value = connection.site_login(name, password)

--- a/feature_server/config/scripts/tdm.py
+++ b/feature_server/config/scripts/tdm.py
@@ -6,7 +6,7 @@ Maintainer: Triplefox
 
 from pyspades.constants import *
 
-import commands
+from piqueserver import commands
 
 def score(connection):
     return connection.protocol.get_kill_count()

--- a/feature_server/config/scripts/timedmute.py
+++ b/feature_server/config/scripts/timedmute.py
@@ -3,7 +3,7 @@
 # by topologist June 30th 2012
 
 from scheduler import Scheduler
-from commands import add, admin, get_player, join_arguments, name
+from piqueserver.commands import add, admin, get_player, join_arguments, name
 
 @name('tm')
 @admin

--- a/feature_server/config/scripts/trusted.py
+++ b/feature_server/config/scripts/trusted.py
@@ -5,7 +5,7 @@ or rubberbanded.
 Maintainer: mat^2 / hompy
 """
 
-from commands import add, admin, get_player
+from piqueserver.commands import add, admin, get_player
 
 S_GRANTED = '{player} is now trusted'
 S_GRANTED_SELF = "You've been granted trust, and can't be votekicked"

--- a/feature_server/config/scripts/votekick.py
+++ b/feature_server/config/scripts/votekick.py
@@ -18,8 +18,8 @@
 # along with pyspades.  If not, see <http://www.gnu.org/licenses/>.
 
 from twisted.internet.reactor import seconds
-from scheduler import Scheduler
-from commands import name, add, get_player, join_arguments, InvalidPlayer
+from piqueserver.scheduler import Scheduler
+from piqueserver.commands import name, add, get_player, join_arguments, InvalidPlayer
 
 REQUIRE_REASON = True
 

--- a/feature_server/config/scripts/votemap.py
+++ b/feature_server/config/scripts/votemap.py
@@ -21,7 +21,7 @@ from pyspades.common import prettify_timespan
 from map import check_rotation
 import random
 from scheduler import Scheduler
-import commands
+from piqueserver import commands
 
 def cancel_verify(connection, instigator):
     return (connection.admin or

--- a/feature_server/server.py
+++ b/feature_server/server.py
@@ -21,6 +21,7 @@ pyspades - default/featured server
 
 import sys
 import os
+import imp
 import json
 import itertools
 import random
@@ -984,9 +985,6 @@ def run():
     runs the server
     """
 
-    # add the config dir to the path so we can import scripts
-    sys.path.append(cfg.config_dir)
-
     try:
         with open(cfg.config_file, 'rb') as f:
             config = json.load(f)
@@ -1010,8 +1008,6 @@ def run():
             sys.exit(1)
         config.update(params)
 
-
-
     # apply scripts
 
     protocol_class = FeatureProtocol
@@ -1024,10 +1020,13 @@ def run():
         # must be a script with this game mode
         script_names.append(game_mode)
 
+    script_dir = os.path.join(cfg.config_dir, 'scripts/')
     for script in script_names[:]:
         try:
-            module = __import__('scripts.%s' % script, globals(), locals(),
-                [script])
+            # NOTE: this finds and loads scripts directly from the script dir
+            # no need for messing with sys.path
+            f, filename, desc = imp.find_module(script, [script_dir])
+            module = imp.load_module(script, f, filename, desc)
             script_objects.append(module)
         except ImportError, e:
             print "(script '%s' not found: %r)" % (script, e)

--- a/feature_server/server.py
+++ b/feature_server/server.py
@@ -61,19 +61,6 @@ def get_git_rev():
     return ret
 
 
-frozen = hasattr(sys, 'frozen')
-
-if frozen:
-    path = os.path.dirname(unicode(sys.executable, sys.getfilesystemencoding()))
-    sys.path.append(path)
-    try:
-        SERVER_VERSION = 'win32 bin - rev %s' % (open('version', 'rb').read())
-    except IOError:
-        SERVER_VERSION = 'win32 bin'
-else:
-    sys.path.append('..')
-    SERVER_VERSION = '%s - rev %s' % (sys.platform, get_git_rev())
-
 if sys.platform == 'linux2':
     try:
         from twisted.internet import epollreactor
@@ -535,7 +522,7 @@ class FeatureProtocol(ServerProtocol):
     game_mode = None # default to None so we can check
     time_announce_schedule = None
 
-    server_version = SERVER_VERSION
+    server_version = cfg.server_version
 
     def __init__(self, interface, config):
         self.config = config

--- a/feature_server/server.py
+++ b/feature_server/server.py
@@ -1020,6 +1020,13 @@ def run():
         # must be a script with this game mode
         script_names.append(game_mode)
 
+    # add this directory (feature_server) to sys.path so scripts can import
+    # modules directly (e.g. `import commands` instead of the more proper
+    # `from piqueserver import commands`
+    # NOTE: only kept for backwards compatibility with scripts originally for
+    # pysnip. Should be removed in the future due to hackiness.
+    sys.path.insert(1, os.path.dirname(os.path.abspath(__file__)))
+
     script_dir = os.path.join(cfg.config_dir, 'scripts/')
     for script in script_names[:]:
         try:

--- a/feature_server/server.py
+++ b/feature_server/server.py
@@ -68,13 +68,6 @@ if sys.platform == 'linux2':
     except ImportError:
         print '(dependencies missing for epoll, using normal reactor)'
 
-if sys.version_info < (2, 7):
-    try:
-        import psyco
-        psyco.full()
-    except ImportError:
-        print '(optional: install psyco for optimizations)'
-
 import pyspades.debug
 from pyspades.server import (ServerProtocol, ServerConnection, position_data,
     grenade_packet, Team)

--- a/feature_server/server.py
+++ b/feature_server/server.py
@@ -987,10 +987,6 @@ def run():
     # add the config dir to the path so we can import scripts
     sys.path.append(cfg.config_dir)
 
-    # add our package to path too so scripts can import `feature_server/`
-    # a better way instead of abs path?
-    sys.path.insert(1, os.path.dirname(os.path.abspath(__file__)))
-
     try:
         with open(cfg.config_file, 'rb') as f:
             config = json.load(f)

--- a/feature_server/statusserver.py
+++ b/feature_server/statusserver.py
@@ -95,7 +95,7 @@ class StatusServerFactory(object):
     last_map_name = None
     overview = None
     def __init__(self, protocol, config):
-        self.env = Environment(loader = PackageLoader('web'))
+        self.env = Environment(loader = PackageLoader('piqueserver.web'))
         self.protocol = protocol
         root = Resource()
         root.putChild('json', JSONPage(self))


### PR DESCRIPTION
- tidies up top level code in `server.py` so that importing it doesn't have side effects (except still for epollreactor installing for twisted - maybe something who knows twisted can fix that sometime)
- cleaner importing scripts using `imp` - no manipulating `sys.path` anymore!
- the original changes to `sys.path` was allowing the scripts to still work with importing files directly from `feature_server` like `import commands` - now you need to `from piqueserver import commands` or `import piqueserver.commands` from scripts.