### PR TITLE
Fix Nosharp

### DIFF
--- a/piqueserver/config/scripts/nosharp.py
+++ b/piqueserver/config/scripts/nosharp.py
@@ -1,10 +1,11 @@
 """
 nosharp.py - kicks player whose name starts with # and also kicks player with no name
-by kmsi(kmsiapps@gmail.com)
-version 3(2017.02.06)
+by kmsi(kmsiapps@gmail.com) & swalladge(samuel@swalladge.id.au)
+version 4(2017.02.13)
  - Added options
  - Now puts player on spectator team instead of kicking
  - Auto-disconnects after specific time(default : 10 seconds)
+ - now it will block names that consist of only whitespace
 """
 from twisted.internet import reactor
 
@@ -23,13 +24,13 @@ def apply_script(protocol, connection, config):
 
             if block_noname and len(self.name.strip()) == 0:
                 self.set_team(self.protocol.spectator_team)
-                self.send_chat('%% Your name is empty. Will be kicked in %s seconds.'
+                self.send_chat('!%% Your name is empty. Will be kicked in %s seconds.'
                                % (autokick_duration))
                 self.autokick_call = reactor.callLater(autokick_duration, self.autokick)
 
             elif block_sharpname and self.name[0] == '#':
                 self.set_team(self.protocol.spectator_team)
-                self.send_chat('%% Your name starts with #. Will be kicked in %s seconds.'
+                self.send_chat('!%% Your name starts with #. Will be kicked in %s seconds.'
                                % (autokick_duration))
                 self.autokick_call = reactor.callLater(autokick_duration, self.autokick)
 


### PR DESCRIPTION
- Fixed OpenSpades protocol prefix( %% ) error caused by %s
- Changed OS protocol prefix from %%(Alert) to !%(Error) 
- Added credits