### PR TITLE
Updates, additions, fixes for gamemodes and scripts

### DIFF
--- a/piqueserver/config/scripts/afk.py
+++ b/piqueserver/config/scripts/afk.py
@@ -95,7 +95,7 @@ def apply_script(protocol, connection, config):
             return connection.on_user_login(self, user_type, verbose)
 
         def on_connect(self):
-            if time_limit:
+            if time_limit and not self.local:
                 self.afk_kick_call = reactor.callLater(
                     time_limit, self.afk_kick)
             self.last_activity = reactor.seconds()

--- a/piqueserver/config/scripts/arena.py
+++ b/piqueserver/config/scripts/arena.py
@@ -347,6 +347,7 @@ def apply_script(protocol, connection, config):
             return returned
 
     class ArenaProtocol(protocol):
+        game_mode = CTF_MODE
         old_respawn_time = None
         old_building = None
         old_killing = None

--- a/piqueserver/config/scripts/arena.py
+++ b/piqueserver/config/scripts/arena.py
@@ -163,15 +163,17 @@ def minimize_block_line(points):
 def get_team_alive_count(team):
     count = 0
     for player in team.get_players():
-        if not player.world_object.dead:
-            count += 1
+        if player.world_object is not None:
+            if not player.world_object.dead:
+                count += 1
     return count
 
 
 def get_team_dead(team):
     for player in team.get_players():
-        if not player.world_object.dead:
-            return False
+        if player.world_object is not None:
+            if not player.world_object.dead:
+                return False
     return True
 
 
@@ -272,14 +274,14 @@ def apply_script(protocol, connection, config):
 
         def on_disconnect(self):
             if self.protocol.arena_running:
-                if self.world_object is not None:
+                if self.world_object is not None and not self.world_object.dead:
                     self.world_object.dead = True
                     self.protocol.check_round_end()
             return connection.on_disconnect(self)
 
         def on_kill(self, killer, type, grenade):
             if self.protocol.arena_running and type != TEAM_CHANGE_KILL:
-                if self.world_object is not None:
+                if self.world_object is not None and not self.world_object.dead:
                     self.world_object.dead = True
                     self.protocol.check_round_end(killer)
             return connection.on_kill(self, killer, type, grenade)
@@ -393,7 +395,7 @@ def apply_script(protocol, connection, config):
                 reactor.callLater(TEAM_COLOR_TIME, self.arena_reset_fog_color)
             if killer is None or killer.team is not team:
                 for player in team.get_players():
-                    if not player.world_object.dead:
+                    if player.world_object is not None and not player.world_object.dead:
                         killer = player
                         break
             if killer is not None:
@@ -496,7 +498,7 @@ def apply_script(protocol, connection, config):
             for player in self.players.values():
                 if player.team.spectator:
                     continue
-                if player.world_object.dead:
+                if player.world_object is not None and player.world_object.dead:
                     player.spawn(random.choice(player.team.arena_spawns))
                 else:
                     player.set_location(

--- a/piqueserver/config/scripts/babel_script.py
+++ b/piqueserver/config/scripts/babel_script.py
@@ -1,0 +1,211 @@
+"""
+babel_script.py last modified 2014-04-04 13:55:07
+Original script by Yourself
+Anti grief by izzy
+Return intel dropped from platform bug fix by a_girl
+
+Release thread:
+http://www.buildandshoot.com/viewtopic.php?t=2586
+
+How to install and configure:
+
+1) Save babel_script.py to 'scripts' folder: http://aloha.pk/files/aos/pyspades/feature_server/scripts/babel_script.py
+2) Save babel.py to 'scripts' folder: http://aloha.pk/files/aos/pyspades/feature_server/scripts/babel.py
+3) Set game_mode to "babel" in config.txt
+4) Add "babel_script" to scripts list in config.txt
+5) Set cap_limit to "10" in config.txt
+"""
+
+from pyspades.constants import *
+from random import randint
+from twisted.internet import reactor
+import commands
+
+# If ALWAYS_ENABLED is False, then babel can be enabled by setting 'babel': True
+# in the map metadat extensions dictionary.
+ALWAYS_ENABLED = True
+
+PLATFORM_WIDTH = 100
+PLATFORM_HEIGHT = 32
+PLATFORM_COLOR = (0, 255, 255, 255)
+BLUE_BASE_COORDS = (256-138, 256)
+GREEN_BASE_COORDS = (256+138, 256)
+SPAWN_SIZE = 40
+
+# Don't touch this stuff
+PLATFORM_WIDTH /= 2
+PLATFORM_HEIGHT /= 2
+SPAWN_SIZE /= 2
+
+
+def get_entity_location(self, entity_id):
+    if entity_id == BLUE_BASE:
+        return BLUE_BASE_COORDS + (self.protocol.map.get_z(*BLUE_BASE_COORDS),)
+    elif entity_id == GREEN_BASE:
+        return GREEN_BASE_COORDS + (self.protocol.map.get_z(*GREEN_BASE_COORDS),)
+    elif entity_id == BLUE_FLAG:
+        return (256 - PLATFORM_WIDTH + 1, 256, 0)
+    elif entity_id == GREEN_FLAG:
+        return (256 + PLATFORM_WIDTH - 1, 256, 0)
+
+
+def get_spawn_location(connection):
+    xb = connection.team.base.x
+    yb = connection.team.base.y
+    xb += randint(-SPAWN_SIZE, SPAWN_SIZE)
+    yb += randint(-SPAWN_SIZE, SPAWN_SIZE)
+    return (xb, yb, connection.protocol.map.get_z(xb, yb))
+
+
+def coord_on_platform(x, y, z):
+    if z <= 2:
+        if x >= (256 - PLATFORM_WIDTH) and x <= (256 + PLATFORM_WIDTH) and y >= (256 - PLATFORM_HEIGHT) and y <= (256 + PLATFORM_HEIGHT):
+            return True
+    if z == 1:
+        if x >= (256 - PLATFORM_WIDTH - 1) and x <= (256 + PLATFORM_WIDTH + 1) and y >= (256 - PLATFORM_HEIGHT - 1) and y <= (256 + PLATFORM_HEIGHT + 1):
+            return True
+    return False
+
+
+def apply_script(protocol, connection, config):
+    allowed_intel_hold_time = config.get('allowed_intel_hold_time', 150)
+
+    class TowerOfBabelConnection(connection):
+        def invalid_build_position(self, x, y, z):
+            if not self.god and self.protocol.babel:
+                if coord_on_platform(x, y, z):
+                    connection.on_block_build_attempt(self, x, y, z)
+                    return True
+            # prevent enemies from building in protected areas
+            if self.team is self.protocol.blue_team:
+                if self.world_object.position.x >= 301 and self.world_object.position.x <= 384 and self.world_object.position.y >= 240 and self.world_object.position.y <= 272:
+                    self.send_chat('You can\'t build near the enemy\'s tower!')
+                    return True
+            if self.team is self.protocol.green_team:
+                if self.world_object.position.x >= 128 and self.world_object.position.x <= 211 and self.world_object.position.y >= 240 and self.world_object.position.y <= 272:
+                    self.send_chat('You can\'t build near the enemy\'s tower!')
+                    return True
+            return False
+
+        def on_block_build_attempt(self, x, y, z):
+            if self.invalid_build_position(x, y, z):
+                return False
+            return connection.on_block_build_attempt(self, x, y, z)
+
+        def on_line_build_attempt(self, points):
+            for point in points:
+                if self.invalid_build_position(*point):
+                    return False
+            return connection.on_line_build_attempt(self, points)
+
+        # anti team destruction
+        def on_block_destroy(self, x, y, z, mode):
+            if self.team is self.protocol.blue_team:
+                if not (self.admin or self.user_types.moderator or self.user_types.guard or self.user_types.trusted) and self.tool is SPADE_TOOL and self.world_object.position.x >= 128 and self.world_object.position.x <= 211 and self.world_object.position.y >= 240 and self.world_object.position.y <= 272:
+                    self.send_chat('You can\'t destroy your team\'s blocks in this area. Attack the enemy\'s tower!')
+                    return False
+                if self.world_object.position.x <= 288:
+                    if self.tool is WEAPON_TOOL:
+                        self.send_chat('You must be closer to the enemy\'s base to shoot blocks!')
+                        return False
+                    if self.tool is GRENADE_TOOL:
+                        self.send_chat('You must be closer to the enemy\'s base to grenade blocks!')
+                        return False
+            if self.team is self.protocol.green_team:
+                if not (self.admin or self.user_types.moderator or self.user_types.guard or self.user_types.trusted) and self.tool is SPADE_TOOL and self.world_object.position.x >= 301 and self.world_object.position.x <= 384 and self.world_object.position.y >= 240 and self.world_object.position.y <= 272:
+                    self.send_chat('You can\'t destroy your team\'s blocks in this area. Attack the enemy\'s tower!')
+                    return False
+                if self.world_object.position.x >= 224:
+                    if self.tool is WEAPON_TOOL:
+                        self.send_chat('You must be closer to the enemy\'s base to shoot blocks!')
+                        return False
+                    if self.tool is GRENADE_TOOL:
+                        self.send_chat('You must be closer to the enemy\'s base to grenade blocks!')
+                        return False
+            return connection.on_block_destroy(self, x, y, z, mode)
+
+        auto_kill_intel_hog_call = None
+
+        # kill intel carrier if held too long
+        def auto_kill_intel_hog(self):
+            self.auto_kill_intel_hog_call = None
+            self.kill()
+            self.protocol.send_chat('God punished %s for holding the intel too long' % (self.name))
+
+        def restore_default_fog_color(self):
+            self.protocol.set_fog_color(getattr(self.protocol.map_info.info, 'fog', (128, 232, 255)))
+
+        def on_flag_take(self):
+            if self.auto_kill_intel_hog_call is not None:
+                self.auto_kill_intel_hog_call.cancel()
+                self.auto_kill_intel_hog_call = None
+            self.auto_kill_intel_hog_call = reactor.callLater(allowed_intel_hold_time, self.auto_kill_intel_hog)
+            # flash team color in sky
+            if self.team is self.protocol.blue_team:
+                self.protocol.set_fog_color(getattr(self.protocol.map_info.info, 'fog', (0, 0, 255)))
+            if self.team is self.protocol.green_team:
+                self.protocol.set_fog_color(getattr(self.protocol.map_info.info, 'fog', (0, 255, 0)))
+            reactor.callLater(0.25, self.restore_default_fog_color)
+            return connection.on_flag_take(self)
+
+        # return intel to platform if dropped
+        def on_flag_drop(self):
+            x, y, z = self.world_object.position.x, self.world_object.position.y, self.world_object.position.z
+            if self.auto_kill_intel_hog_call is not None:
+                self.auto_kill_intel_hog_call.cancel()
+                self.auto_kill_intel_hog_call = None
+            if z >= 0:
+                self.reset_flag()
+            elif (x >= (256 + PLATFORM_WIDTH)) or (x < (256 - PLATFORM_WIDTH)):
+                self.reset_flag()
+            elif (y >= (256 + PLATFORM_HEIGHT)) or (y < (256 - PLATFORM_HEIGHT)):
+                self.reset_flag()
+            self.protocol.set_fog_color(getattr(self.protocol.map_info.info, 'fog', (255, 0, 0)))
+            reactor.callLater(0.25, self.restore_default_fog_color)
+            return connection.on_flag_drop(self)
+
+        def reset_flag(self):
+            self.protocol.onectf_reset_flags()
+            self.protocol.send_chat('The intel has returned to the heavens')
+
+        def on_flag_capture(self):
+            if self.auto_kill_intel_hog_call is not None:
+                self.auto_kill_intel_hog_call.cancel()
+                self.auto_kill_intel_hog_call = None
+            return connection.on_flag_capture(self)
+
+        def on_reset(self):
+            if self.auto_kill_intel_hog_call is not None:
+                self.auto_kill_intel_hog_call.cancel()
+                self.auto_kill_intel_hog_call = None
+            return connection.on_reset(self)
+
+    class TowerOfBabelProtocol(protocol):
+        babel = False
+
+        def on_map_change(self, map):
+            extensions = self.map_info.extensions
+            if ALWAYS_ENABLED:
+                self.babel = True
+            else:
+                if extensions.has_key('babel'):
+                    self.babel = extensions['babel']
+                else:
+                    self.babel = False
+            if self.babel:
+                self.map_info.cap_limit = 1
+                self.map_info.get_entity_location = get_entity_location
+                self.map_info.get_spawn_location = get_spawn_location
+                for x in xrange(256 - PLATFORM_WIDTH, 256 + PLATFORM_WIDTH):
+                    for y in xrange(256 - PLATFORM_HEIGHT, 256 + PLATFORM_HEIGHT):
+                        map.set_point(x, y, 1, PLATFORM_COLOR)
+            return protocol.on_map_change(self, map)
+
+        def is_indestructable(self, x, y, z):
+            if self.babel:
+                if coord_on_platform(x, y, z):
+                    protocol.is_indestructable(self, x, y, z)
+                    return True
+            return protocol.is_indestructable(self, x, y, z)
+
+    return TowerOfBabelProtocol, TowerOfBabelConnection

--- a/piqueserver/config/scripts/passreload.py
+++ b/piqueserver/config/scripts/passreload.py
@@ -4,15 +4,18 @@
 from piqueserver import commands
 from piqueserver.commands import add, admin
 import json
+import cfg
+import os.path
 
 
 @admin
 def reloadconfig(connection):
     new_config = {}
     try:
-        new_config = json.load(open('config.txt', 'r'))
+        new_config = json.load(open(
+            os.path.join(cfg.config_dir, cfg.config_file), 'r'))
         if not isinstance(new_config, dict):
-            raise ValueError('config.txt is not a mapping type')
+            raise ValueError('%s is not a mapping type' % cfg.config_file)
     except ValueError, v:
         print 'Error reloading config:', v
         return 'Error reloading config. Check pyspades log for details.'

--- a/piqueserver/config/scripts/passreload.py
+++ b/piqueserver/config/scripts/passreload.py
@@ -18,7 +18,7 @@ def reloadconfig(connection):
             raise ValueError('%s is not a mapping type' % cfg.config_file)
     except ValueError, v:
         print 'Error reloading config:', v
-        return 'Error reloading config. Check pyspades log for details.'
+        return 'Error reloading config. Check log for details.'
     connection.protocol.config.update(new_config)
     connection.protocol.reload_passes()
     return 'Config reloaded!'

--- a/piqueserver/config/scripts/push.py
+++ b/piqueserver/config/scripts/push.py
@@ -1,0 +1,385 @@
+"""
+push.py last modified 2013-10-30 17:39:12
+Contributors: danhezee, StackOverflow, izzy, Danke, noway421, IAmYourFriend
+
+The concept:
+    Each team spawns at a set location with the enemy intel.
+    They must "push" the intel towards their control point, which is also at a
+    set location.
+
+How to setup new maps:
+    Spawn and CP locations must be configured via extensions in the map's
+    map_name.txt metadata. Example:
+
+extensions = {
+    'push': True,
+    'push_spawn_range' : 5,
+    'push_blue_spawn' : (91, 276, 59),
+    'push_blue_cp' : (91, 276, 59),
+    'push_green_spawn' : (78, 86, 59),
+    'push_green_cp' : (78, 86, 59),
+    'water_damage' : 100
+}
+
+Additional, but optional extensions, to mark each teams build area and prevent
+the enemy from building there (and thereby helping the enemy). The build area
+is defined by x and y of upper left corner, followed by x and y of bottom right
+corner on the map. Example:
+
+    'push_blue_build_area' : (172, 140, 216, 402),
+    'push_green_build_area' : (266, 145, 309, 408),
+
+ToDo:
+    Block check by global array (For example, blockdata.py), not block color.
+    One time violet block spawns. Wtf!
+    Serverside player blocks stack. Cannot control filling stack on clientside.
+"""
+
+
+from pyspades.constants import *
+from pyspades.common import make_color
+from pyspades.server import set_color, block_action
+from piqueserver.commands import add, admin
+from twisted.internet.task import LoopingCall
+from random import randint
+
+import colorsys
+
+
+def byte_rgb_to_hls(rgb):
+    hls = colorsys.rgb_to_hls(*tuple(c / 255.0 for c in rgb))
+    return tuple(int(round(c * 255)) for c in hls)
+
+
+def byte_hls_to_rgb(hls):
+    rgb = colorsys.hls_to_rgb(*tuple(c / 255.0 for c in hls))
+    return tuple(int(round(c * 255)) for c in rgb)
+
+
+def byte_middle_range(byte):
+    half = 50 / 2.0  # half of (byte/5.1)
+    min = byte - half
+    max = byte + half
+    if min < 0:
+        min = 0
+        max = half
+    elif max > 255:
+        min = 255 - half
+        max = 255
+    return int(round(min)), int(round(max))
+
+
+# If ALWAYS_ENABLED is False, then the 'push' key must be set to True in
+# the 'extensions' dictionary in the map's map_name.txt metadata
+ALWAYS_ENABLED = True
+CANT_DESTROY = "You can't destroy your team's blocks. Attack the enemy!"
+NO_BLOCKS = "You out of blocks! Kill yourself or reach base to refill."
+BUILDING_AT_CP = "You can't build near your command post!"
+BUILDING_AT_ENEMY_AREA = "Don't build for your enemy!"
+# team is associated intel team
+
+
+def reset_intel(protocol, team):
+    if team is protocol.green_team and protocol.blue_team.spawn is not None:
+        z = protocol.map.get_z(*protocol.blue_team.spawn)
+        pos = (protocol.blue_team.spawn[0],
+               protocol.blue_team.spawn[1],
+               z)
+
+    if team is protocol.blue_team and protocol.green_team.spawn is not None:
+        z = protocol.map.get_z(*protocol.green_team.spawn)
+        pos = (protocol.green_team.spawn[0],
+               protocol.green_team.spawn[1],
+               z)
+
+    team.flag.set(*pos)  # If spawn not set, it would throw error.
+    team.flag.update()
+    protocol.send_chat("The %s intel has been reset." % team.name)
+
+
+@admin
+def resetblueintel(connection):
+    reset_intel(connection.protocol, connection.protocol.blue_team)
+
+
+@admin
+def resetgreenintel(connection):
+    reset_intel(connection.protocol, connection.protocol.green_team)
+
+
+add(resetblueintel)
+add(resetgreenintel)
+
+
+def get_entity_location(self, entity_id):
+    if entity_id == BLUE_BASE:
+        return self.protocol.blue_team.cp
+    elif entity_id == GREEN_BASE:
+        return self.protocol.green_team.cp
+
+    # this next part might seem counter intuitive but you need the blue intel
+    # to spawn near the greens and vice versa
+    elif entity_id == BLUE_FLAG:
+        return self.protocol.green_team.spawn
+    elif entity_id == GREEN_FLAG:
+        return self.protocol.blue_team.spawn
+
+
+def get_spawn_location(connection):
+    # distance from spawn center to randomly spawn in
+    spawn_range = connection.protocol.spawn_range
+
+    if connection.team.spawn is not None:
+        xb = connection.team.spawn[0]
+        yb = connection.team.spawn[1]
+        xb += randint(-spawn_range, spawn_range)
+        yb += randint(-spawn_range, spawn_range)
+        return (xb, yb, connection.protocol.map.get_z(xb, yb))
+
+
+def apply_script(protocol, connection, config):
+    class PushConnection(connection):
+
+        def invalid_build_position_check(self, x, y, check_area, error_message):
+            # check_area is made of x-pos, y-pos of upper left corner,
+            # and x-pos, y-pos of opposite corner (bottom right)
+            if (x >= check_area[0] and y >= check_area[1] and
+                    x <= check_area[2] and y <= check_area[3]):
+                self.send_chat(error_message)
+                return True
+            else:
+                return False
+
+        def invalid_build_position(self, x, y, z):
+            # prevent teams from building near their cp
+            cp_block_range = 8
+            if self.team is self.protocol.blue_team:
+                blue_cp_area = (self.protocol.blue_team.cp[0] - cp_block_range,
+                                self.protocol.blue_team.cp[1] - cp_block_range,
+                                self.protocol.blue_team.cp[0] + cp_block_range,
+                                self.protocol.blue_team.cp[1] + cp_block_range)
+                invalid_pos = self.invalid_build_position_check(x, y, blue_cp_area, BUILDING_AT_CP)
+                if invalid_pos is True:
+                    return True
+            if self.team is self.protocol.green_team:
+                green_cp_area = (self.protocol.green_team.cp[0] - cp_block_range,
+                                 self.protocol.green_team.cp[1] - cp_block_range,
+                                 self.protocol.green_team.cp[0] + cp_block_range,
+                                 self.protocol.green_team.cp[1] + cp_block_range)
+                invalid_pos = self.invalid_build_position_check(x, y, green_cp_area, BUILDING_AT_CP)
+                if invalid_pos is True:
+                    return True
+            # prevent teams from building in enemy build area
+            if (self.team is self.protocol.blue_team and
+                    self.protocol.blue_team.build_area is not None):
+                invalid_pos = self.invalid_build_position_check(
+                                                                x, y,
+                                                                self.protocol.green_team.build_area,
+                                                                BUILDING_AT_ENEMY_AREA)
+                if invalid_pos is True:
+                    return True
+            if (self.team is self.protocol.green_team and
+                    self.protocol.green_team.build_area is not None):
+                invalid_pos = self.invalid_build_position_check(x, y,
+                                                                self.protocol.blue_team.build_area,
+                                                                BUILDING_AT_ENEMY_AREA)
+                if invalid_pos is True:
+                    return True
+
+            return False
+
+        def on_login(self, name):
+            self.mylastblocks = [
+                (-4, -1, -14),
+                (-11, -5, -9),
+                (-19, -20, -8)]
+            return connection.on_login(self, name)
+
+        def random_color(self):
+            (h, l, s) = self.team.hls
+            l = randint(self.team.light_range[0], self.team.light_range[1])
+            color = byte_hls_to_rgb((h, l, s))
+
+            self.color = color
+            set_color.player_id = self.player_id
+            set_color.value = make_color(*color)
+            self.send_contained(set_color)
+            self.protocol.send_contained(set_color, save=True)
+
+        def build_block(self, x, y, z, looped=False):
+            if ((x < 0 or x > 511 or
+                y < 0 or y > 511 or
+                z < 1 or z > 61)
+                    is False):
+                self.protocol.map.set_point(x, y, z, self.color)
+                block_action.x = x
+                block_action.y = y
+                block_action.z = z
+                block_action.value = BUILD_BLOCK
+                block_action.player_id = self.player_id
+                self.protocol.send_contained(block_action, save=True)
+
+        def on_line_build_attempt(self, points):
+            can_build = connection.on_line_build_attempt(self, points)
+            if can_build is False:
+                return False
+
+            if self.blocks < len(points):
+                self.send_chat(NO_BLOCKS)
+                return False
+
+            for point in points:
+                if self.invalid_build_position(*point):
+                    return False
+
+            spawn = self.team.spawn
+            spawn_range = self.protocol.spawn_range
+
+            for point in points:
+                x, y, z = point[0], point[1], point[2]
+                self.random_color()
+
+            return can_build
+
+        def on_block_build_attempt(self, x, y, z):
+            can_build = connection.on_block_build_attempt(self, x, y, z)
+            if can_build is False:
+                return False
+
+            if self.blocks < 0:
+                self.send_chat(NO_BLOCKS)
+                return False
+
+            if self.invalid_build_position(x, y, z):
+                return False
+
+            self.mylastblocks.pop(0)
+            self.mylastblocks.append((x, y, z))
+            self.random_color()
+            return can_build
+
+        def on_block_destroy(self, x, y, z, value):
+            if not (self.admin or
+                    self.god or
+                    self.user_types.moderator or
+                    self.user_types.guard or
+                    self.user_types.trusted):
+                if value == DESTROY_BLOCK:
+                    blocks = ((x, y, z),)
+                elif value == SPADE_DESTROY:
+                    blocks = ((x, y, z), (x, y, z + 1), (x, y, z - 1))
+                elif value == GRENADE_DESTROY:
+                    blocks = []
+                    for nade_x in xrange(x - 1, x + 2):
+                        for nade_y in xrange(y - 1, y + 2):
+                            for nade_z in xrange(z - 1, z + 2):
+                                blocks.append((nade_x, nade_y, nade_z))
+
+                is_in_last = lambda block: any(last == block
+                                               for last in self.mylastblocks)
+
+                for block in blocks:
+                    if is_in_last(block):
+                        continue
+
+                    block_info = self.protocol.map.get_point(*block)
+
+                    if block_info[0] is True:
+                        block_hls = byte_rgb_to_hls(block_info[1])
+                        if self.team is self.protocol.blue_team:
+                            team_hls = self.protocol.blue_team.hls
+                            # if hue and saturation match
+                            if (block_hls[0] == team_hls[0] and
+                                    block_hls[2] == team_hls[2]):
+                                self.send_chat(CANT_DESTROY)
+                                return False
+                        elif self.team is self.protocol.green_team:
+                            team_hls = self.protocol.green_team.hls
+                            if (block_hls[0] == team_hls[0] and
+                                    block_hls[2] == team_hls[2]):
+                                self.send_chat(CANT_DESTROY)
+                                return False
+
+                for block in blocks:
+                    if is_in_last(block):
+                        self.mylastblocks.remove(block)
+                        self.mylastblocks.append((-1, -1, -1))
+
+            return connection.on_block_destroy(self, x, y, z, value)
+
+    class PushProtocol(protocol):
+        game_mode = CTF_MODE
+        push = False
+        spawn_range = 5
+        check_loop = None
+        reset_intel_after_seconds = 300
+        reset_intel_blue_timer = 0
+        reset_intel_green_timer = 0
+
+        def __init__(self, *arg, **kw):
+            protocol.__init__(self, *arg, **kw)
+            self.blue_team.hls = byte_rgb_to_hls(self.blue_team.color)
+            self.blue_team.light_range = byte_middle_range(
+                self.blue_team.hls[1])
+
+            self.green_team.hls = byte_rgb_to_hls(self.green_team.color)
+            self.green_team.light_range = byte_middle_range(
+                self.green_team.hls[1])
+
+        def check_intel_locations(self):
+            if self.blue_team.flag is not None:
+                if self.blue_team.flag.get()[2] >= 63:
+                    self.reset_intel_blue_timer = 0
+                    reset_intel(self, self.blue_team)
+                elif self.blue_team.flag.player is None:
+                    self.reset_intel_blue_timer += 1
+                    if self.reset_intel_blue_timer >= self.reset_intel_after_seconds:
+                        self.reset_intel_blue_timer = 0
+                        reset_intel(self, self.blue_team)
+                else:
+                    self.reset_intel_blue_timer = 0
+
+            if self.green_team.flag is not None:
+                if self.green_team.flag.get()[2] >= 63:
+                    self.reset_intel_green_timer = 0
+                    reset_intel(self, self.green_team)
+                elif self.green_team.flag.player is None:
+                    self.reset_intel_green_timer += 1
+                    if self.reset_intel_green_timer >= self.reset_intel_after_seconds:
+                        self.reset_intel_green_timer = 0
+                        reset_intel(self, self.green_team)
+                else:
+                    self.reset_intel_green_timer = 0
+
+        def on_map_change(self, map):
+            extensions = self.map_info.extensions
+            if ALWAYS_ENABLED:
+                self.push = True
+            else:
+                self.push = extensions.get('push', False)
+
+            if self.push:
+                # distance from spawn center to randomly spawn in
+                self.spawn_range = extensions.get('push_spawn_range')
+
+                self.blue_team.spawn = extensions.get('push_blue_spawn')
+                self.blue_team.cp = extensions.get('push_blue_cp')
+                self.blue_team.build_area = extensions.get('push_blue_build_area')
+
+                self.green_team.spawn = extensions.get('push_green_spawn')
+                self.green_team.cp = extensions.get('push_green_cp')
+                self.green_team.build_area = extensions.get('push_green_build_area')
+
+                self.map_info.get_entity_location = get_entity_location
+                self.map_info.get_spawn_location = get_spawn_location
+
+                if self.check_loop is not None:
+                    self.check_loop.stop()
+                self.reset_intel_blue_timer = 0
+                self.reset_intel_green_timer = 0
+                self.check_loop = LoopingCall(self.check_intel_locations)
+                self.check_loop.start(1)
+
+            return protocol.on_map_change(self, map)
+
+    return PushProtocol, PushConnection

--- a/piqueserver/config/scripts/votekick.py
+++ b/piqueserver/config/scripts/votekick.py
@@ -166,7 +166,7 @@ class Votekick(object):
             raise VotekickFailure(S_SELF_VOTEKICK)
         elif protocol.get_required_votes() <= 0:
             raise VotekickFailure(S_NOT_ENOUGH_PLAYERS)
-        elif victim.admin or victim.rights.cancel:
+        elif victim.admin or victim.rights.cancel or victim.local:
             raise VotekickFailure(S_VOTEKICK_IMMUNE)
         elif not instigator.admin and (last_votekick is not None and
                                        seconds() - last_votekick < cls.interval):
@@ -257,8 +257,8 @@ def apply_script(protocol, connection, config):
 
         def get_required_votes(self):
             # votekicks are invalid if this returns <= 0
-            player_count = sum(not player.disconnected for player in
-                               self.players.itervalues()) - 1
+            player_count = sum(not player.disconnected and not player.local
+                               for player in self.players.itervalues()) - 1
             return int(player_count / 100.0 * required_percentage)
 
         def on_map_leave(self):

--- a/pyspades/server.py
+++ b/pyspades/server.py
@@ -210,6 +210,7 @@ class ServerConnection(BaseConnection):
     last_block = None
     map_data = None
     last_position_update = None
+    local = False
 
     def __init__(self, *arg, **kw):
         BaseConnection.__init__(self, *arg, **kw)
@@ -221,6 +222,8 @@ class ServerConnection(BaseConnection):
         self.rapids = SlidingWindow(RAPID_WINDOW_ENTRIES)
 
     def on_connect(self):
+        if self.local:
+            return
         if self.peer.eventData != self.protocol.version:
             self.disconnect(ERROR_WRONG_VERSION)
             return


### PR DESCRIPTION
- Updated votekick.py to newer version including the command /togglevotekick
- Updated arena and babel gamemode (originated from aloha.pk)
- Added support for bots by adding the attribute 'local' to ServerConnection, allows scripts to create and distinguish local connections
- Added optional config parameter 'remove_intel' to tdm, to allow non-ctf-related gameplay
- Added the push gamemode
- Fixed passreload.py (was not working due to refactorings concerning the config)