### PR TITLE
No longer treat 'Deuce' differently from others

### DIFF
--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -165,9 +165,6 @@ class ServerConnection(BaseConnection):
         self.team = team
         if self.name is None:
             name = contained.name
-            # vanilla AoS behaviour
-            if name == 'Deuce':
-                name = name + str(self.player_id)
             self.name = self.protocol.get_name(name)
             self.protocol.players[self.name, self.player_id] = self
             self.on_login(self.name)

--- a/pyspades/server.py
+++ b/pyspades/server.py
@@ -259,6 +259,11 @@ class ServerProtocol(BaseProtocol):
                 player.spawn()
 
     def get_name(self, name):
+        '''
+        Sanitizes `name` and modifies it so that it doesn't collide with other names connected to the server.
+
+        Returns the fixed name.
+        '''
         name = name.replace('%', '')
         new_name = name
         names = [p.name.lower() for p in self.players.values()]


### PR DESCRIPTION
- name collisions resolved the same way for all names
- add docstring to get_name
- fix #104