### PR TITLE
make ip_getter url configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,6 @@ notifications:
         urls:
             - "https://scalar.vector.im/api/neb/services/hooks/dHJhdmlzLWNpLyU0MG5vdGFmaWxlJTNBbWF0cml4Lm9yZy8lMjFzcFNwVVNjSmplcmJsWGlWekElM0FtYXRyaXgub3Jn"
         on_success: change  # always|never|change
-        on_failure: always
+        on_failure: change
         on_start: never
+        on_cancel: never

--- a/piqueserver/config/config.json
+++ b/piqueserver/config/config.json
@@ -24,6 +24,7 @@
         "Cheating isn't welcome. Griefing is frowned upon. Have fun!"
     ],
     "master" : false,
+    "ip_getter" : "https://services.buildandshoot.com/getip",
     "max_players" : 32,
     "max_connections_per_ip" : 3,
     "port" : 32887,

--- a/piqueserver/config/config.json
+++ b/piqueserver/config/config.json
@@ -24,7 +24,6 @@
         "Cheating isn't welcome. Griefing is frowned upon. Have fun!"
     ],
     "master" : false,
-    "ip_getter" : "https://services.buildandshoot.com/getip",
     "max_players" : 32,
     "max_connections_per_ip" : 3,
     "port" : 32887,

--- a/piqueserver/server.py
+++ b/piqueserver/server.py
@@ -96,13 +96,6 @@ def random_choice_cycle(choices):
         yield random.choice(choices)
 
 
-IP_GETTER = 'https://services.buildandshoot.com/getip'
-# other tools:
-# http://www.domaintools.com/research/my-ip/myip.xml
-# http://checkip.dyndns.com/
-# http://icanhazip.com/
-
-
 class FeatureTeam(Team):
     locked = False
 
@@ -336,12 +329,20 @@ class FeatureProtocol(ServerProtocol):
         self.set_master()
 
         self.http_agent = web_client.Agent(reactor)
-        self.get_external_ip()
+
+        # ip_getter should be a url that returns solely the requester's public ip in the response body
+        # other tools:
+        # http://www.domaintools.com/research/my-ip/myip.xml
+        # http://checkip.dyndns.com/
+        # http://icanhazip.com/
+        ip_getter = config.get('ip_getter', 'https://services.buildandshoot.com/getip')
+        if ip_getter:
+            self.get_external_ip()
 
     @inlineCallbacks
-    def get_external_ip(self):
+    def get_external_ip(self, ip_getter):
         try:
-            ip = yield self.getPage(IP_GETTER)
+            ip = yield self.getPage(ip_getter)
         except OSError as e:
             print("Getting external IP failed:", e)
             return

--- a/piqueserver/server.py
+++ b/piqueserver/server.py
@@ -337,7 +337,7 @@ class FeatureProtocol(ServerProtocol):
         # http://icanhazip.com/
         ip_getter = config.get('ip_getter', 'https://services.buildandshoot.com/getip')
         if ip_getter:
-            self.get_external_ip()
+            self.get_external_ip(ip_getter)
 
     @inlineCallbacks
     def get_external_ip(self, ip_getter):

--- a/piqueserver/server.py
+++ b/piqueserver/server.py
@@ -330,12 +330,18 @@ class FeatureProtocol(ServerProtocol):
 
         self.http_agent = web_client.Agent(reactor)
 
-        # ip_getter should be a url that returns solely the requester's public ip in the response body
+        # ip_getter should be a url that returns only the requester's public ip in the response body
         # other tools:
-        # http://www.domaintools.com/research/my-ip/myip.xml
-        # http://checkip.dyndns.com/
-        # http://icanhazip.com/
-        ip_getter = config.get('ip_getter', 'https://services.buildandshoot.com/getip')
+        # https://icanhazip.com/
+        # https://api.ipify.org
+        #
+        # default to http on windows - see https://github.com/piqueserver/piqueserver/issues/215
+        if sys.platform == 'win32':
+            default_ip_getter = 'http://services.buildandshoot.com/getip'
+        else:
+            default_ip_getter = 'https://services.buildandshoot.com/getip'
+
+        ip_getter = config.get('ip_getter', default_ip_getter)
         if ip_getter:
             self.get_external_ip(ip_getter)
 

--- a/piqueserver/server.py
+++ b/piqueserver/server.py
@@ -347,7 +347,7 @@ class FeatureProtocol(ServerProtocol):
             print("Getting external IP failed:", e)
             return
 
-        self.ip = ip
+        self.ip = ip.strip()
         self.identifier = make_server_identifier(ip, self.port)
         print('Server identifier is %s' % self.identifier)
 


### PR DESCRIPTION
In config.json:

```
"ip_getter": "http://url.tld"
```

Behaviour:

- not set: uses default ip_getter (https://services.buildandshoot.com/getip)
- set to empty string: does not query for external ip at all (useful if
you want more privacy)
- set to alternative url: uses that url to get the ip

NOTE: To work correctly, the configured url should respond with the client's
public ip address in the response body. That is, if you `curl <url>`, it
should only print out the public ip address, nothing more.

helps with #215 (though doesn't fix underlying issue)