### PR TITLE
Replace ascii encode hack with actual string escaping

### DIFF
--- a/piqueserver/player.py
+++ b/piqueserver/player.py
@@ -10,7 +10,7 @@ import pyspades
 from pyspades.constants import (ERROR_BANNED, DESTROY_BLOCK, SPADE_DESTROY,
                                 GRENADE_DESTROY, ERROR_KICKED, BLOCK_TOOL)
 from pyspades.server import ServerConnection
-from pyspades.common import encode, prettify_timespan, Vertex3
+from pyspades.common import encode, escape_control_codes, prettify_timespan, Vertex3
 from pyspades.world import Character
 
 # TODO: move these where they belong
@@ -72,8 +72,7 @@ class FeatureConnection(ServerConnection):
             self.send_lines(self.protocol.motd)
 
     def on_login(self, name):
-        # Dirty hack to remove all non-ascii chars, please fix
-        self.printable_name = name.encode().decode('ascii', 'replace')
+        self.printable_name = escape_control_codes(name)
         if len(self.printable_name) > 15:
             self.kick(silent=True)
         print('%s (IP %s, ID %s) entered the game!' % (self.printable_name,
@@ -114,7 +113,7 @@ class FeatureConnection(ServerConnection):
             log_message += ' -> %s' % result
             for i in reversed(result.split("\n")):
                 self.send_chat(i)
-        print(log_message.replace("\n", "\\n").encode('ascii', 'replace'))
+        print(escape_control_codes(log_message))
 
     def _can_build(self):
         if not self.can_complete_line_build:
@@ -347,7 +346,7 @@ class FeatureConnection(ServerConnection):
             self.last_chat = current_time
 
         # TODO: replace with logging
-        print(message.encode('ascii', 'replace'))
+        print(escape_control_codes(message))
 
         return value
 

--- a/pyspades/common.pyx
+++ b/pyspades/common.pyx
@@ -95,18 +95,20 @@ def decode(value):
 
 ascii_control_code_regexp = re.compile(r'[\x00-\x1F]')
 
-def _replace_hex(s):
-    return r"\x{:h}".format(s)
+def _replace_hex(match):
+    return r"\x{:x}".format(ord(match.group()))
 
 def escape_control_codes(untrusted_str):
     """escape all ascii control codes in a string note: this still leaves
     things like special unicode characters in place"""
 
-    # Make the common symbols prettier
-    untrusted_str = untrusted_str.translate({13: '\\r', 10: '\\n', 9: '\\t'})
+    # Escapes common symbols
+    # untrusted_str = untrusted_str.translate({13: '\\r', 10: '\\n', 9: '\\t'})
+    # py2 doesn't support the prettier implementation
+    untrusted_str = untrusted_str.replace('\r', '\\r').replace('\t', '\\t').replace('\n', '\\n')
 
     # Escape all characters under 0x20 with their hex notation
-    return ascii_control_code_regexp.sub(untrusted_str, _replace_hex)
+    return ascii_control_code_regexp.sub(_replace_hex, untrusted_str)
 
 cdef class Vertex3:
     # NOTE: for the most part this behaves as a 2d vector, with z being tacked on

--- a/pyspades/common.pyx
+++ b/pyspades/common.pyx
@@ -16,6 +16,7 @@
 # along with pyspades.  If not, see <http://www.gnu.org/licenses/>.
 
 from math import pi
+import re
 
 cdef extern from "math.h":
     double sqrt(double x)
@@ -88,6 +89,24 @@ def encode(value):
 def decode(value):
     if value is not None:
         return value.decode('cp437', 'replace')
+
+# Printing untrusted ASCII control codes to the console can have a number of
+# annoying to dangerous side effects depending on the terminal emulator used
+
+ascii_control_code_regexp = re.compile(r'[\x00-\x1F]')
+
+def _replace_hex(s):
+    return r"\x{:h}".format(s)
+
+def escape_control_codes(untrusted_str):
+    """escape all ascii control codes in a string note: this still leaves
+    things like special unicode characters in place"""
+
+    # Make the common symbols prettier
+    untrusted_str = untrusted_str.translate({13: '\\r', 10: '\\n', 9: '\\t'})
+
+    # Escape all characters under 0x20 with their hex notation
+    return ascii_control_code_regexp.sub(untrusted_str, _replace_hex)
 
 cdef class Vertex3:
     # NOTE: for the most part this behaves as a 2d vector, with z being tacked on

--- a/tests/pyspades/test_common.py
+++ b/tests/pyspades/test_common.py
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 """
 test pyspades/common.pyx
 """
@@ -6,7 +7,7 @@ from __future__ import print_function
 
 from twisted.trial import unittest
 
-from pyspades.common import get_color, to_coordinates, coordinates
+from pyspades.common import escape_control_codes, get_color, to_coordinates, coordinates
 
 class TestCommonThings(unittest.TestCase):
 
@@ -18,3 +19,14 @@ class TestCommonThings(unittest.TestCase):
 
     def test_from_coords(self):
         self.assertEqual(coordinates("H8"), (448, 448))
+
+    def test_escape_control_codes(self):
+        test_cases = [
+            ("\x1b[6;30;42mGreen!\x1b[0m", "\\x1b[6;30;42mGreen!\\x1b[0m"), # ANSI
+            ("\x1b[6;30;42mGreen世界!\x1b[0m", "\\x1b[6;30;42mGreen世界!\\x1b[0m"), # ANSI with utf-8
+            ("hello\n\t","hello\\n\\t"), # acii controll codes
+            ("hello ", "hello "), # normal
+            ("世界", "世界") # normal utf-8
+        ]
+        for unescaped, want in test_cases:
+            self.assertEqual(escape_control_codes(unescaped), want)


### PR DESCRIPTION
The goal is to go through all places where `.encode("ascii")` is used and check if using the replace function makes more sense. Really, ascii is used nowhere in piqueserver so all cases where ascii encoding is will likely have to be replaced.
  
closes:  #251