### PR TITLE
Send kill packets for dead players before initial spawn

### DIFF
--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -178,6 +178,14 @@ class ServerConnection(BaseConnection):
             if self.world_object is not None:
                 self.world_object.delete()
                 self.world_object = None
+        # send kill packets for dead players
+        for player in self.protocol.players.values():
+            if player.player_id != self.player_id and player.world_object \
+            and player.world_object.dead:
+                kill_action.killer_id = player.player_id
+                kill_action.player_id = player.player_id
+                kill_action.kill_type = FALL_KILL
+                self.send_contained(kill_action)
         self.spawn()
 
     @register_packet_handler(loaders.OrientationData)
@@ -927,13 +935,6 @@ class ServerConnection(BaseConnection):
                 existing_player.team = player.team.id
                 existing_player.color = make_color(*player.color)
                 saved_loaders.append(existing_player.generate())
-                # send kill packets for dead players
-                if player.player_id != self.player_id and player.world_object \
-                and player.world_object.dead:
-                    kill_action.killer_id = player.player_id
-                    kill_action.player_id = player.player_id
-                    kill_action.kill_type = FALL_KILL
-                    saved_loaders.append(kill_action.generate())
 
             self.player_id = self.protocol.player_ids.pop()
             self.protocol.update_master()

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -927,8 +927,10 @@ class ServerConnection(BaseConnection):
                 existing_player.team = player.team.id
                 existing_player.color = make_color(*player.color)
                 saved_loaders.append(existing_player.generate())
-                if player.world_object.dead:
-                    kill_action.killer_id = 31
+                # send kill packets for dead players
+                if player.player_id != self.player_id and player.world_object \
+                and player.world_object.dead:
+                    kill_action.killer_id = player.player_id
                     kill_action.player_id = player.player_id
                     kill_action.kill_type = FALL_KILL
                     saved_loaders.append(kill_action.generate())

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -927,6 +927,11 @@ class ServerConnection(BaseConnection):
                 existing_player.team = player.team.id
                 existing_player.color = make_color(*player.color)
                 saved_loaders.append(existing_player.generate())
+                if player.world_object.dead:
+                    kill_action.killer_id = 31
+                    kill_action.player_id = player.player_id
+                    kill_action.kill_type = FALL_KILL
+                    saved_loaders.append(kill_action.generate())
 
             self.player_id = self.protocol.player_ids.pop()
             self.protocol.update_master()


### PR DESCRIPTION
If we send them right after we are done sending the map it only works for openspades and betterspades.
If we send them right before initial spawn it works for openspades, betterspades and voxlap so going for this.
Experimented to hide them from kill feed but no possible way.

closes: #246