### PR TITLE
fix /client command

### DIFF
--- a/piqueserver/core_commands/player.py
+++ b/piqueserver/core_commands/player.py
@@ -1,19 +1,17 @@
 from piqueserver.commands import command, get_player
 
 @command("client", "cli")
-def client(connection, *args):
+def client(connection, target=None):
     """
     Tell you information about your client or the client of a given player
     /client [player]
     """
-    if len(args) == 0:
+    if not target:
         player = connection
         who_is = "You are"
-    if len(args) == 1:
+    else:
         player = get_player(connection.protocol, target)
         who_is = player.name + " is"
-    else:
-       return "Invalid number of arguments"
 
     info = player.client_info
     version = info.get("version", None)
@@ -28,6 +26,7 @@ def client(connection, *args):
         version_string,
         info.get("os_info", "Unknown")
     )
+
 
 @command()
 def weapon(connection, value):

--- a/pyspades/bytes.pxd
+++ b/pyspades/bytes.pxd
@@ -17,7 +17,7 @@ cdef class ByteReader:
     cpdef long long readInt(self, bint unsigned = ?, bint big_endian = ?) \
                             except LONG_LONG_ERROR
     cpdef float readFloat(self, bint big_endian = ?) except? FLOAT_ERROR
-    cpdef readString(self, int size = ?)
+    cpdef bytes readString(self, int size = ?)
     cpdef ByteReader readReader(self, int size = ?)
     cpdef int dataLeft(self)
     cdef void _skip(self, int bytecount)

--- a/pyspades/bytes.pyx
+++ b/pyspades/bytes.pyx
@@ -147,13 +147,13 @@ cdef class ByteReader:
         cdef char * pos = self.check_available(4)
         return read_float(pos, big_endian)
 
-    cpdef readString(self, int size = -1):
+    cpdef bytes readString(self, int size = -1):
         """read a string
         Arguments:
             size (int): If set, read ``size`` bytes, else read all bytes available
 
         Returns:
-            float: The value of the bytes as float
+            bytes: The value of the bytes
         """
         value = self.pos
         if size == -1:
@@ -162,7 +162,7 @@ cdef class ByteReader:
             size = self.end - self.pos
             value = value[:size]
         self.pos += size
-        return value
+        return bytes(value)
 
     cpdef ByteReader readReader(self, int size = -1):
         cdef int left = self.dataLeft()

--- a/pyspades/contained.pyx
+++ b/pyspades/contained.pyx
@@ -850,7 +850,7 @@ cdef class VersionResponse(Loader):
     cdef public:
         str client
         tuple version
-        bytes os_info
+        str os_info
 
     cpdef read(self, ByteReader reader):
         magic_no = reader.readByte(True)
@@ -861,7 +861,7 @@ cdef class VersionResponse(Loader):
                 reader.readByte(True),
                 reader.readByte(True),
             )
-            self.os_info = reader.readString()
+            self.os_info = decode(reader.readString())
         # There are other magic numbers, but we currently do not implement them
 
     cpdef write(self, ByteWriter writer):


### PR DESCRIPTION
* replace (broken) implicit `char *` to str conversion with decode()
 * add target back as optional arg the way it should probably originally
 have been
 * fix other stuff

closes #270 