### PR TITLE
Add tox to dev-requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,4 @@ coveralls
 pytest
 pytest-cov
 Sphinx
+tox


### PR DESCRIPTION
Tox was missing from dev-requirements