### PR TITLE
Replace initialize() with Team constructor calls

### DIFF
--- a/piqueserver/game_modes/infiltration.py
+++ b/piqueserver/game_modes/infiltration.py
@@ -78,8 +78,9 @@ class DummyPlayer():
         intel_capture.winning = winning
         self.protocol.send_contained(intel_capture, save=True)
         if winning:
-            self.team.initialize()
-            self.team.other.initialize()
+            self.team = self.team(*self.team.get_init_values())
+            self.team.other = self.team(*self.team.other.get_init_values())
+            self.team.other.other = self.team
             for entity in self.protocol.entities:
                 entity.update()
             for player in list(itervalues(self.protocol.players)):

--- a/pyspades/server.py
+++ b/pyspades/server.py
@@ -230,8 +230,7 @@ class ServerProtocol(BaseProtocol):
         self.map = map_obj
         self.world.map = map_obj
         self.on_map_change(map_obj)
-        self.team_1.initialize()
-        self.team_2.initialize()
+        self.reset_teams()
         if self.game_mode == TC_MODE:
             self.reset_tc()
         self.players = MultikeyDict()
@@ -254,8 +253,7 @@ class ServerProtocol(BaseProtocol):
         player is the player which should be awarded the necessary captures to
         end the game
         """
-        self.team_1.initialize()
-        self.team_2.initialize()
+        self.reset_teams()
         if self.game_mode == CTF_MODE:
             if player is None:
                 player = list(self.players.values())[0]
@@ -275,6 +273,14 @@ class ServerProtocol(BaseProtocol):
         for player in self.players.values():
             if player.team is not None:
                 player.spawn()
+
+    def reset_teams(self):
+        self.team_1 = self.team_class(*self.team_1.get_init_values())
+        self.team_2 = self.team_class(*self.team_2.get_init_values())
+        self.team_1.other = self.team_2
+        self.team_2.other = self.team_1
+        self.teams[self.team_1.id] = self.team_1
+        self.teams[self.team_2.id] = self.team_2
 
     def get_name(self, name):
         '''

--- a/pyspades/team.py
+++ b/pyspades/team.py
@@ -21,6 +21,19 @@ class Team(object):
         self.protocol = protocol
         self.color = color
         self.spectator = spectator
+        if self.should_init():
+            self.initialize()
+
+    def should_init(self):
+        """
+        The first time teams are created the protocol lacks some fields required to
+        set flag and base for the CTF mode. Once map_info is set it should be safe
+        to call set_flag and set_base.
+        """
+        return self.protocol.map_info is not None
+
+    def get_init_values(self):
+        return self.id, self.name, self.color, self.spectator, self.protocol
 
     def get_players(self):
         for player in self.protocol.players.values():

--- a/tests/pyspades/test_teams.py
+++ b/tests/pyspades/test_teams.py
@@ -1,0 +1,62 @@
+# -*- encoding: utf-8 -*-
+"""
+test pyspades/teams.pyx
+"""
+from pyspades.constants import CTF_MODE
+
+from pyspades.protocol import BaseProtocol
+
+from pyspades.server import ServerProtocol
+from twisted.trial import unittest
+
+from pyspades.team import Team
+
+
+class TestTeams(unittest.TestCase):
+    name = "Team name"
+    color = (255, 0, 255)
+
+    def test_initial_values(self):
+        team = Team(0, self.name, self.color, False, MockServerProtocol())
+        self.assertEquals(0, team.kills)
+        self.assertEquals(0, team.score)
+
+    def test_team_from_team(self):
+        team_template = Team(0, self.name, self.color, False, MockServerProtocol())
+        team_template.kills = 9
+        team_template.score = 5
+        team = Team(*team_template.get_init_values())
+        self.assertEquals(0, team.kills)
+        self.assertEquals(0, team.score)
+        self.assertEquals(team_template.name, team.name)
+        self.assertEquals(team_template.color, team.color)
+
+    def test_team_others(self):
+        # Team.get_init_values() should not return values of field "other"
+        team_1 = Team(0, "team_1", (255, 0, 255), False, MockServerProtocol())
+        team_2 = Team(1, "team_2", (127, 127, 127), False, MockServerProtocol())
+        team_1.other = team_2
+        team_2.other = team_1
+        team_1 = Team(*team_1.get_init_values())
+        self.assertEquals(None, team_1.other)
+
+
+# Dummy class mocking the behavior of ServerProtocol
+class MockServerProtocol:
+    game_mode = None
+    entities = None
+    map_info = None
+
+    def __init__(self):
+        self.game_mode = CTF_MODE
+        self.entities = []
+        self.map_info = True
+
+    def get_random_location(self, a, b):
+        return 0, 0, 0
+
+    def on_flag_spawn(self, x, y, z, a, b):
+        return None
+
+    def on_base_spawn(self, a, b, c, d, e):
+        return None


### PR DESCRIPTION
Fixes #178 

Team objects can be created based on other instances by extracting the required fields and passing them to the constructor.

Some issues with references arise when continuously creating new instances but this is covered by bundling all the reference switching into ServerProtocol.reset_teams()