### PR TITLE
remove __future__ directives only useful in py2

### DIFF
--- a/piqueserver/commands.py
+++ b/piqueserver/commands.py
@@ -18,8 +18,6 @@
 # pylint: disable=too-many-lines
 # pylint: disable=wildcard-import,unused-wildcard-import
 
-from __future__ import print_function, unicode_literals
-
 import traceback
 import inspect
 import warnings

--- a/piqueserver/console.py
+++ b/piqueserver/console.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with pyspades.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
-
 import sys
 
 from twisted.internet import reactor

--- a/piqueserver/core_commands/server.py
+++ b/piqueserver/core_commands/server.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, unicode_literals
 from piqueserver.commands import command, join_arguments
 
 @command('servername', admin_only=True)

--- a/piqueserver/irc.py
+++ b/piqueserver/irc.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with pyspades.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
-
 import re
 import random
 from itertools import groupby, chain

--- a/piqueserver/map.py
+++ b/piqueserver/map.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with pyspades.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
-
 import os
 import imp
 import math

--- a/piqueserver/player.py
+++ b/piqueserver/player.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, unicode_literals
-
 import math
 from typing import List, Tuple, Optional, Union
 

--- a/piqueserver/run.py
+++ b/piqueserver/run.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, unicode_literals
 
 import os
 import filecmp

--- a/piqueserver/scripts/aimbot2.py
+++ b/piqueserver/scripts/aimbot2.py
@@ -3,8 +3,6 @@ Plugin to detect and react to possible aimbot users
 
 maintained by: ?
 """
-# So we can do `x / y` instead of `float(x) / y`
-from __future__ import division
 import os
 import csv
 import re

--- a/piqueserver/scripts/badmin.py
+++ b/piqueserver/scripts/badmin.py
@@ -2,7 +2,6 @@
 # He might not always get it right, but he'll get it done, and isn't that what really matters?
 # -Requirements: blockinfo.py (for grief detection), ratio.py (for k/d ratio), aimbot2.py (hit accuracy)
 
-from __future__ import print_function
 from twisted.internet import reactor
 from pyspades.common import prettify_timespan
 from pyspades.constants import *

--- a/piqueserver/scripts/geoip.py
+++ b/piqueserver/scripts/geoip.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, unicode_literals
 import os
 from piqueserver.commands import command, get_player
 from piqueserver.config import config

--- a/piqueserver/scripts/markers.py
+++ b/piqueserver/scripts/markers.py
@@ -25,8 +25,6 @@ VV_ENABLED and CHAT_MARKERS below.
 Maintainer: hompy
 """
 
-from __future__ import unicode_literals
-
 import csv
 from io import StringIO
 from collections import deque, defaultdict

--- a/piqueserver/scripts/memcheck.py
+++ b/piqueserver/scripts/memcheck.py
@@ -5,7 +5,6 @@ garbage found.
 Maintainer: mat^2
 """
 
-from __future__ import print_function
 from twisted.internet import reactor
 from twisted.internet.task import LoopingCall
 import gc

--- a/piqueserver/scripts/passreload.py
+++ b/piqueserver/scripts/passreload.py
@@ -1,8 +1,6 @@
 # passreload.py
 # written by Danke
 
-from __future__ import print_function
-
 import json
 import os.path
 

--- a/piqueserver/scripts/votekick.py
+++ b/piqueserver/scripts/votekick.py
@@ -18,7 +18,6 @@
 # along with pyspades.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from __future__ import print_function
 from twisted.internet.reactor import seconds
 from piqueserver.scheduler import Scheduler
 from piqueserver.commands import command, admin, get_player, join_arguments, CommandError

--- a/piqueserver/server.py
+++ b/piqueserver/server.py
@@ -19,7 +19,6 @@
 """
 pyspades - default/featured server
 """
-from __future__ import print_function, unicode_literals
 import sys
 import os
 import imp

--- a/piqueserver/statistics.py
+++ b/piqueserver/statistics.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with pyspades.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
-
 import json
 
 from twisted.internet.protocol import (ReconnectingClientFactory,

--- a/pylintrc
+++ b/pylintrc
@@ -206,7 +206,7 @@ init-import=no
 
 # List of qualified module names which can have objects that can redefine
 # builtins.
-redefining-builtins-modules=future.builtins
+redefining-builtins-modules=
 
 
 [DESIGN]

--- a/pyspades/client.py
+++ b/pyspades/client.py
@@ -19,8 +19,6 @@
 Client implementation - WIP
 """
 
-from __future__ import print_function
-
 from twisted.internet.protocol import DatagramProtocol
 from twisted.internet import reactor
 from pyspades.protocol import BaseConnection, in_packet

--- a/pyspades/master.py
+++ b/pyspades/master.py
@@ -19,8 +19,6 @@
 Implementation of the 0,75 master server protocol
 """
 
-from __future__ import unicode_literals
-
 from pyspades.loaders import Loader
 from pyspades.protocol import BaseConnection
 from pyspades.constants import MASTER_VERSION

--- a/pyspades/protocol.py
+++ b/pyspades/protocol.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with pyspades.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
-
 from twisted.internet import reactor
 from twisted.internet.task import LoopingCall
 from pyspades.bytes import ByteWriter

--- a/pyspades/server.py
+++ b/pyspades/server.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with pyspades.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
-
 import random
 from itertools import product
 import enet

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import print_function
-
 import sys
 import os
 from distutils.core import run_setup

--- a/tests/pyspades/test_bytes.py
+++ b/tests/pyspades/test_bytes.py
@@ -1,8 +1,6 @@
 """
 tests for bytes.pyx
 """
-from __future__ import print_function
-
 from twisted.trial import unittest
 
 from pyspades.bytes import ByteReader, ByteWriter

--- a/tests/pyspades/test_common.py
+++ b/tests/pyspades/test_common.py
@@ -3,8 +3,6 @@
 test pyspades/common.pyx
 """
 
-from __future__ import print_function
-
 from twisted.trial import unittest
 
 from pyspades.common import escape_control_codes, get_color, to_coordinates, coordinates

--- a/tests/pyspades/test_constants.py
+++ b/tests/pyspades/test_constants.py
@@ -2,8 +2,6 @@
 test pyspades/protocol.py
 """
 
-from __future__ import print_function
-
 from twisted.trial import unittest
 from pyspades import constants
 

--- a/tests/pyspades/test_mapgenerator.py
+++ b/tests/pyspades/test_mapgenerator.py
@@ -2,8 +2,6 @@
 test pyspades/protocol.py
 """
 
-from __future__ import print_function
-
 from pyspades import mapgenerator
 
 from twisted.trial import unittest

--- a/tests/pyspades/test_player.py
+++ b/tests/pyspades/test_player.py
@@ -2,8 +2,6 @@
 test pyspades/protocol.py
 """
 
-from __future__ import print_function
-
 from twisted.trial import unittest
 from pyspades import player
 

--- a/tests/pyspades/test_protocol.py
+++ b/tests/pyspades/test_protocol.py
@@ -2,8 +2,6 @@
 test pyspades/protocol.py
 """
 
-from __future__ import print_function
-
 from twisted.trial import unittest
 from pyspades import protocol
 

--- a/tests/pyspades/test_server.py
+++ b/tests/pyspades/test_server.py
@@ -2,8 +2,6 @@
 test pyspades/server.py
 """
 
-from __future__ import print_function
-
 from twisted.trial import unittest
 from pyspades import server
 


### PR DESCRIPTION
these should be able to be safely removed since supported python versions include these in the core language