### PR TITLE
Make log level configurable 

### DIFF
--- a/piqueserver/config/config.toml
+++ b/piqueserver/config/config.toml
@@ -240,7 +240,7 @@ guard = [
 ]
 
 [logging]
-
+loglevel = "info"
 # enable the debug logging
 debug_log = false
 

--- a/piqueserver/server.py
+++ b/piqueserver/server.py
@@ -38,6 +38,7 @@ from twisted.internet.defer import inlineCallbacks
 from twisted.python import log
 from twisted.python.logfile import DailyLogFile
 from twisted.logger import Logger, textFileLogObserver
+from twisted.logger import FilteringLogObserver, LogLevelFilterPredicate, LogLevel
 from twisted.logger import globalLogPublisher
 from twisted.web import client as web_client
 from twisted.internet.tcp import Port
@@ -101,6 +102,7 @@ game_mode = config.option('game_mode', default='ctf')
 random_rotation = config.option('random_rotation', default=False)
 passwords = config.option('passwords', default={})
 logfile = logging_config.option('logfile', default='./logs/log.txt')
+loglevel = logging_config.option('loglevel', default='info')
 map_rotation = config.option('rotation', default=['classicgen', 'random'],
                              validate=lambda x: isinstance(x, list))
 default_time_limit = config.option(
@@ -284,8 +286,10 @@ class FeatureProtocol(ServerProtocol):
                 logging_file = DailyLogFile(log_filename, '.')
             else:
                 logging_file = open(log_filename, 'a')
+            predicate = LogLevelFilterPredicate(LogLevel.levelWithName(loglevel.get()))
+            observer = FilteringLogObserver(textFileLogObserver(sys.stderr), [predicate])
             globalLogPublisher.addObserver(textFileLogObserver(logging_file))
-            globalLogPublisher.addObserver(textFileLogObserver(sys.stderr))
+            globalLogPublisher.addObserver(observer)
             log.info('piqueserver started on %s' % time.strftime('%c'))
 
         self.config = config_dict


### PR DESCRIPTION
Closes: #344

Currently it only filters logs going out to stderr, so log files will still contain debug logs. [example](https://gist.github.com/godwhoa/28930192ba272870376dd16888dbd027)