### PR TITLE
Add cmdlist command & changes to help command

### DIFF
--- a/piqueserver/config/config.toml
+++ b/piqueserver/config/config.toml
@@ -12,16 +12,14 @@ motd = [
 ]
 
 # info displaying when user types the /help command
-# if not defined, /help will display a list of available commands
 # String interpolation is allowed. Possible values are:
 # 'server_name', 'map_name', 'map_author', 'map_description', 'game_mode'
 help = [
   "Server name: %(server_name)s", "Map: %(map_name)s by %(map_author)s",
   "Game mode: %(game_mode)s",
-  "/streak    Shows how many kills in a row you got without dying",
-  "/intel     Tells you who's got the enemy intel",
-  "/votekick  Start a vote to temporarily ban a disruptive player",
-  "/time      Remaining time until forced map reset"
+  "/cmdlist Prints all avalable commands",
+  "/help <command_name> Gives description and usage info for a command",
+  "/help Prints this message"
 ]
 
 # list of messages to send when the user sends the /rules command

--- a/piqueserver/server.py
+++ b/piqueserver/server.py
@@ -173,7 +173,14 @@ ip_getter_option = config.option('ip_getter', default_ip_getter)
 name_option = config.option(
     'name', default='piqueserver #%s' % random.randrange(0, 2000))
 motd_option = config.option('motd')
-help_option = config.option('help')
+help_option = config.option('help', default=[
+    'Server name: %(server_name)s',
+    'Map: %(map_name)s by %(map_author)s',
+    'Game mode: %(game_mode)s',
+    '/cmdlist Prints all avalable commands',
+    '/help <command_name> Gives description and usage info for a command',
+    '/help Prints this message',
+    ])
 rules_option = config.option('rules')
 tips_option = config.option('tips')
 network_interface = config.option('network_interface', default='')


### PR DESCRIPTION
Changes:
 - `/help` no longer lists commands `/cmdlist` does that instead
 - `/help <command_name>` prints usage/description of a command
 - `/help` with no args prints out the help message
 -  Added a default for `help` message option, which has notes about `/cmdlist` and `/help` commands.
 -  `/cmdlist` gives a helpful output for regular players and compact output for admins