### PR TITLE
Fix for map.copy()

### DIFF
--- a/piqueserver/scripts/rollback.py
+++ b/piqueserver/scripts/rollback.py
@@ -27,6 +27,7 @@ Options
 import os
 import time
 import operator
+import copy
 
 from twisted.internet.task import LoopingCall
 from pyspades.vxl import VXLData
@@ -246,7 +247,7 @@ def apply_script(protocol, connection, config):
                 yield packets_sent
 
         def on_map_change(self, map):
-            self.rollback_map = map.copy()
+            self.rollback_map = copy.copy(map)
             protocol.on_map_change(self, map)
 
         def on_map_leave(self):


### PR DESCRIPTION
Fix for map not having copy() function. Alternatively, it could go right in map.py. Up to you piqueserver folks...

2018-10-09 17:27:55+0200 [-]     self.rollback_map = map.copy()
2018-10-09 17:27:55+0200 [-] AttributeError: 'builtin_function_or_method' object has no attribute 'copy'