### PR TITLE
Add unstable feature-exchange packet

### DIFF
--- a/piqueserver/server.py
+++ b/piqueserver/server.py
@@ -672,7 +672,7 @@ class FeatureProtocol(ServerProtocol):
             """do the actual clearing of bans"""
 
             bans_count = len(self.bans)
-            log.debug("starting ban vacuum with {count} bans",
+            log.info("starting ban vacuum with {count} bans",
                       count=bans_count)
             start_time = time.time()
 

--- a/pyspades/bytes.pyx
+++ b/pyspades/bytes.pyx
@@ -234,10 +234,6 @@ cdef class ByteReader:
     def __len__(self):
         return self.size
 
-    def __str__(self):
-        # NOTE: __str__ is only supported for python2 support
-        return self.data[:self.size]
-
     def __bytes__(self):
         return self.data[:self.size]
 
@@ -292,10 +288,6 @@ cdef class ByteWriter:
 
     cpdef size_t tell(self):
         return get_stream_pos(self.stream)
-
-    def __str__(self):
-        # NOTE: __str__ is only supported for python2 support
-        return get_stream(self.stream)
 
     def __bytes__(self):
         return get_stream(self.stream)

--- a/pyspades/contained.pyx
+++ b/pyspades/contained.pyx
@@ -951,3 +951,41 @@ cdef class VersionResponse(Loader):
         writer.writeByte(self.id, True)
 
 register_packet(VersionResponse)
+
+
+cdef class FeatureExchange(Loader):
+    """This packet describes the features of one participant to the other.
+    Features are key-value data, with a numbered ID and arbitrary bytes as
+    data
+
+    THIS PACKET IS CURRENTLY INOFFICIAL AND MAY BE CHANGED AT ANY TIME
+    """
+    id = 40
+
+    cdef public:
+        list features
+
+    cpdef read(self, ByteReader reader):
+        self.features = []
+        while reader.dataLeft():
+            feat_id = reader.readByte(True)
+            count = reader.readByte(True)
+            data = reader.read(count)
+            self.features.append((feat_id, data))
+
+
+    cpdef write(self, ByteWriter writer):
+        for feat_id, value in self.features:
+            count = len(value)
+            if not 0 <= feat_id <= 255:
+                raise ValueError(
+                    "feature IDs must be 0-255, not {}".format(feat_id))
+            if count > 255:
+                raise ValueError(
+                    "feature values length must be 0-255, not {}".format(count))
+
+            writer.writeByte(feat_id, True)
+            writer.writeByte(count, True)
+            writer.write(value)
+
+register_packet(FeatureExchange)

--- a/tests/pyspades/test_contained.py
+++ b/tests/pyspades/test_contained.py
@@ -1,0 +1,51 @@
+"""
+tests for contained.pyx
+"""
+from twisted.trial import unittest
+
+from pyspades import contained
+from pyspades.bytes import ByteWriter, ByteReader
+
+class TestContained(unittest.TestCase):
+    """tests for ByteReader"""
+
+    def test_write_feature_exchange(self):
+        features = [
+            (1, b"\xFF\x12"),
+            (2, b"a"),
+            (5, b"\x00"),
+            (255, b"A" * 12),
+        ]
+
+        cnt = contained.FeatureExchange()
+        cnt.features = features
+        self.assertEqual(
+            bytes(cnt.generate()),
+            b'\x01\x02\xff\x12\x02\x01a\x05\x01\x00\xff\x0cAAAAAAAAAAAA'
+        )
+
+    def test_write_invalid_feature_exchange(self):
+        cnt = contained.FeatureExchange()
+
+        cnt.features = [(1, b"\x00" * 256)]
+        self.assertRaises(ValueError, cnt.generate)
+
+        cnt.features = [(-2, b"\x00")]
+        self.assertRaises(ValueError, cnt.generate)
+
+        cnt.features = [(300, b"\x00")]
+        self.assertRaises(ValueError, cnt.generate)
+
+    def test_read_feature_exchange(self):
+        data = b'\x10\x03\xff\x00\x12\x02\x01a\xff\x03123'
+
+        reader = ByteReader(data)
+        cnt = contained.FeatureExchange(reader)
+        self.assertEqual(
+            cnt.features,
+            [
+                (16, b"\xff\x00\x12"),
+                (2, b"a"),
+                (255, b"123"),
+            ]
+        )


### PR DESCRIPTION
This would allow the client/server to check and send attributes to each other
in a standardized manner