### PR TITLE
Set up CI with Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,55 @@
+# Python package
+# Create and test a Python package on multiple Python versions.
+# Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/python
+
+jobs:
+
+- job: 'Test'
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  strategy:
+    matrix:
+      Python27:
+        python.version: '2.7'
+      Python35:
+        python.version: '3.5'
+      Python36:
+        python.version: '3.6'
+      Python37:
+        python.version: '3.7'
+    maxParallel: 4
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+      architecture: 'x64'
+
+  - script: python -m pip install --upgrade pip && pip install -r requirements.txt
+    displayName: 'Install dependencies'
+
+  - script: |
+      pip install pytest
+      pytest tests --doctest-modules --junitxml=junit/test-results.xml
+    displayName: 'pytest'
+
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFiles: '**/test-results.xml'
+      testRunTitle: 'Python $(python.version)'
+    condition: succeededOrFailed()
+
+- job: 'Publish'
+  dependsOn: 'Test'
+  pool:
+    vmImage: 'Ubuntu 16.04'
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.x'
+      architecture: 'x64'
+
+  - script: python setup.py sdist
+    displayName: 'Build sdist'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,4 +37,4 @@ jobs:
 
   - script: |
       pytest --cov=piqueserver --cov=pyspades
-      displayName: 'Test'
+    displayName: 'Test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,51 +5,36 @@
 
 jobs:
 
-- job: 'Test'
+- job: 'Windows'
   pool:
-    vmImage: 'Ubuntu 16.04'
+    vmImage: 'VS2017-Win2016'
   strategy:
     matrix:
-      Python27:
-        python.version: '2.7'
-      Python35:
+      Python35x64:
         python.version: '3.5'
-      Python36:
+        python.arch: 'x64'
+      Python36x64:
         python.version: '3.6'
-      Python37:
-        python.version: '3.7'
+        python.arch: 'x64'
     maxParallel: 4
 
   steps:
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '$(python.version)'
-      architecture: 'x64'
+      architecture: '$(python.arch)'
 
-  - script: python -m pip install --upgrade pip && pip install -r requirements.txt
+  - script: |
+      python -m pip install --upgrade pip
+      pip install -r requirements.txt
+      pip install -r dev-requirements.txt
     displayName: 'Install dependencies'
 
   - script: |
-      pip install pytest
-      pytest tests --doctest-modules --junitxml=junit/test-results.xml
-    displayName: 'pytest'
+      python setup.py install
+      python setup.py build_ext --inplace
+    displayName: 'Build'
 
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFiles: '**/test-results.xml'
-      testRunTitle: 'Python $(python.version)'
-    condition: succeededOrFailed()
-
-- job: 'Publish'
-  dependsOn: 'Test'
-  pool:
-    vmImage: 'Ubuntu 16.04'
-
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '3.x'
-      architecture: 'x64'
-
-  - script: python setup.py sdist
-    displayName: 'Build sdist'
+  - script: |
+      pytest --cov=piqueserver --cov=pyspades
+      displayName: 'Test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,7 @@ jobs:
 
   - script: |
       python -m pip install --upgrade pip
+      pip install pypiwin32
       pip install -r requirements.txt
       pip install -r dev-requirements.txt
     displayName: 'Install dependencies'


### PR DESCRIPTION
Progress: Added envs. for Python 3.5, 3.6 x64. Builds are green!
Need to decide if it's worth it or not. 
Azure Pipelines lacks build caching making builds 6min(it spends 5min on installing all the dependencies). 
On the bright side it has low queue time and parallel builds.