### PR TITLE
move appveyor build config to repo

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,48 @@
+version: 1.0.{build}
+pull_requests:
+  do_not_increment_build_number: true
+image: Visual Studio 2017
+shallow_clone: true
+
+environment:
+  PATH: '%PYTHON%;%PYTHON%\Scripts;%PATH%'
+  matrix:
+  - PYTHON: C:\Python36-x64
+    DO_EXE: whynot
+  - PYTHON: C:\Python35-x64
+  - PYTHON: C:\Python37-x64
+  - PYTHON: C:\Python36
+  - PYTHON: C:\Python35
+  - PYTHON: C:\Python37
+
+install:
+- cmd: >-
+    python -m pip install -U pip wheel setuptools
+
+    pip --version
+
+    if defined DO_EXE (pip install -U pyinstaller)
+
+    pip install -r requirements.txt
+
+    pip install -r dev-requirements.txt
+
+build_script:
+- cmd: >-
+    python --version
+
+    python setup.py build_ext --inplace -c msvc
+
+    python setup.py build -c msvc
+
+    python setup.py sdist
+
+    python setup.py bdist_wheel
+
+test_script:
+- cmd: pytest
+
+artifacts:
+- path: dist/*
+
+deploy: off

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,6 @@ pygeoip>=0.3.2,<0.4
 # ssh
 cryptography
 pyasn1
+
+# windows specific
+pypiwin32; platform_system=="Windows"


### PR DESCRIPTION
This adds the appveyor.yml export at the time of writing.

See https://www.appveyor.com/docs/build-configuration/#configuring-build for info on configuring build and how the appveyor UI and repo yml file interact.