### PR TITLE
Add better farbuild exploit mitigation

### DIFF
--- a/piqueserver/player.py
+++ b/piqueserver/player.py
@@ -125,59 +125,18 @@ class FeatureConnection(ServerConnection):
         log.info(escape_control_codes(log_message))
 
     def _can_build(self) -> bool:
-        if not self.can_complete_line_build:
-            return False
         if not self.building:
             return False
         if not self.god and not self.protocol.building:
             return False
 
+        return True
+
     def on_block_build_attempt(self, x: int, y: int, z: int) -> bool:
         return self._can_build()
 
-    def on_secondary_fire_set(self, secondary):
-
-        # Inlined from fbpatch.py
-        # Author: Nick Christensen AKA a_girl
-        # Distant Drag Build Client Bug Patch for (0.75) and possibly (0.76)
-        #
-        # if right mouse button has been clicked to initiate drag building;
-        # distinguishes from the right click release that marks the end point.
-        if secondary:
-            if self.tool == BLOCK_TOOL:  # 1 refers to block tool; if the tool in hand is a block
-                # grab player current position at drag build start
-                position = self.world_object.position
-                # grab player current orientation at drag build start
-                vector = self.world_object.orientation
-                # probably unnecessary, but makes sure vector values are
-                # between 0 and 1 inclusive
-                vector.normalize()
-                # creates a line object starting at player and following
-                # their point of view.
-                c = Character(self.world_object.world, position, vector)
-                # finds coordinates of the first block this line strikes.
-                line_start = c.cast_ray()
-                if line_start:  # if player is pointing at a valid point.  Distant solid blocks will return False
-                    distance = (
-                        Vertex3(*line_start) - Vertex3(position.x, position.y, position.z)).length()
-                    if distance > 6:
-                        self.can_complete_line_build = False
-                    else:
-                        self.can_complete_line_build = True
-                else:
-                    self.can_complete_line_build = False
-
     def on_line_build_attempt(self, points) -> bool:
-        if self._can_build() == False:
-            return False
-
-        # originally from the bugfix.py script
-        # prevent "unlimited tower" crash, fix by Danko
-        for point in points:
-            x, y, z = point
-            if x < 0 or x > 511 or y < 0 or y > 511 or z < 0 or z > 61:
-                return False
-        return True
+        return self._can_build()
 
     def on_line_build(self, points) -> None:
         if self.god:

--- a/pyspades/common.pyx
+++ b/pyspades/common.pyx
@@ -237,7 +237,19 @@ cdef class Vertex3:
         cdef Vector * a = self.value
         return sqrt(a.x * a.x + a.y * a.y + a.z * a.z)
 
+    def distance(self, Vertex3 other):
+        """calculate euclidean (straight line) distance between two `Vertex3` as
+        points in 3d space. Equivalent to ``(a - b).length()``."""
+        cdef Vector * a = self.value
+        cdef Vector * b = other.value
+        x = a.x - b.x
+        y = a.y - b.y
+        z = a.z - b.z
+        return sqrt(x**2 + y**2 + z**2)
+
     def length_sqr(self):
+        """calculate the square length of the vertex3. This is a bit faster than
+        getting the length, as it avoids the expensive `sqrt` call."""
         cdef Vector * a = self.value
         return a.x * a.x + a.y * a.y + a.z * a.z
 

--- a/pyspades/vxl.pyx
+++ b/pyspades/vxl.pyx
@@ -90,6 +90,11 @@ cdef class VXLData:
             return None
         return make_color_tuple(get_color(x, y, z, self.map))
 
+    def is_valid_position(self, int x, int y, int z):
+        """return if the value is a valid position within the bounds of the
+        map"""
+        return is_valid_position(x, y, z)
+
     cpdef int get_z(self, int x, int y, int start = 0):
         '''
         Returns the first z coordinate that is solid beginning from `start` and


### PR DESCRIPTION
This mitigation used to be very flakey and had many false positives.
Inspired by 1AmYF's new fbpatch2 mitigation script, which is much
better than the original fbpatch mitigation, we now record and check the
start location of the line build in addition to the end location.

This is now also more readable because these checks are actually in the correct place now, right with the other packet validity checks.