### PR TITLE
Replace Pillow with pypng

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,7 @@ COPY requirements.txt /usr/src/app/
 # Note: manylinux wheel support isn't enabled by default for alpinelinux
 # we temporarly enable it for pyenet since it is compatible
 RUN apk add --no-cache --virtual .build-deps-cython gcc musl-dev \
-    && apk add --no-cache --virtual .build-deps-pillow zlib-dev jpeg-dev libffi-dev openssl-dev \
-    && apk add --no-cache zlib jpeg \
+    && apk add --no-cache --virtual .build-deps-crypto libffi-dev openssl-dev \
     \
     && echo "manylinux1_compatible = True" > /usr/local/lib/python3.6/_manylinux.py \
     && pip install pyenet \
@@ -20,7 +19,7 @@ RUN apk add --no-cache --virtual .build-deps-cython gcc musl-dev \
     && pip install --no-cache-dir -r requirements.txt \
     \
     && apk del .build-deps-cython \
-    && apk del .build-deps-pillow
+    && apk del .build-deps-crypto
 
 # The fact that we removed gcc beforehand makes us download it again
 # This is remedied by building the server core first and leaving all .py scripts 

--- a/piqueserver/statusserver.py
+++ b/piqueserver/statusserver.py
@@ -18,7 +18,7 @@
 import json
 from io import BytesIO
 
-from PIL import Image
+import png
 from jinja2 import Environment, PackageLoader
 from twisted.internet import reactor
 from twisted.web import server
@@ -135,9 +135,9 @@ class StatusServerFactory(object):
                 self.last_map_name != self.protocol.map_info.name or
                 current_time - self.last_overview > OVERVIEW_UPDATE_INTERVAL):
             overview = self.protocol.map.get_overview(rgba=True)
-            image = Image.frombytes('RGBA', (512, 512), overview)
+            w = png.Writer(512, 512, alpha=True)
             data = BytesIO()
-            image.save(data, 'png')
+            w.write_array(data, overview)
             self.overview = data.getvalue()
             self.last_overview = current_time
             self.last_map_name = self.protocol.map_info.name

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@
 Cython>=0.27,<1
 Twisted[tls]>=17
 Jinja2>=2,<3
-Pillow>=5.1.0,<6
 pyenet
 typing
 toml
+pypng==0.0.19
 
 # from command
 pygeoip>=0.3.2,<0.4

--- a/setup.py
+++ b/setup.py
@@ -128,14 +128,14 @@ setup(
         'Cython>=0.27,<1',
         'Twisted[tls]>=17,<19',
         'Jinja2>=2,<3',  # status server is part of our 'vanilla' package
-        'Pillow>=5.1.0,<6',
+        'pypng==0.0.19',
         'pyenet',
         'toml',
         'typing'
     ],
     extras_require={
         'from': ['geoip2>=2.9,<3.0'],
-        # 'statusserver': ['Jinja2>=2.8,<2.9', 'Pillow>=3.4.2,<3.5'],
+        # 'statusserver': ['Jinja2>=2.8,<2.9', 'pypng==0.0.19'],
         'ssh': [
             'cryptography>=2.1.4,<2.2',
             'pyasn1>=0.4.2,<0.5'


### PR DESCRIPTION
Reasoning:
 - No extra baggage, our only use case is generating a PNG
 - Even if we want to draw, better off doing it on the front-end
 - Written in pure python, fewer system dependencies(libjpeg, zlib)
 - As fast or faster than PIL(If performance is of concern)