### PR TITLE
preliminary protocol extension support

### DIFF
--- a/pyspades/contained.pyx
+++ b/pyspades/contained.pyx
@@ -951,3 +951,34 @@ cdef class VersionResponse(Loader):
         writer.writeByte(self.id, True)
 
 register_packet(VersionResponse)
+
+
+cdef class ProtocolExtensionInfo(Loader):
+    """packet used to exchange the list of supported protocol extensions between
+    server and client
+
+    extensions is a list of (extension_id, version) tuples
+    """
+    id = 60
+
+    cdef public:
+        list extensions
+
+    cpdef read(self, ByteReader reader):
+        extension_count = reader.readByte(True)
+        extensions = []
+        for _ in range(extension_count):
+            extensions.append(
+                (reader.readByte(True), reader.readByte(True))
+            )
+        self.extensions = extensions
+
+    cpdef write(self, ByteWriter writer):
+        writer.writeByte(self.id, True)
+
+        writer.writeByte(len(self.extensions), True)
+
+        for ext in self.extensions:
+            writer.writeByte(ext[0], ext[1])
+
+register_packet(ProtocolExtensionInfo)

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -5,11 +5,11 @@ import shlex
 from itertools import product
 import textwrap
 import re
+from typing import Any, Optional, Sequence, Tuple, Union, Dict
 
 from twisted.internet import reactor
 from twisted.logger import Logger
 import enet
-from typing import Any, Optional, Sequence, Tuple, Union
 
 from pyspades.protocol import BaseConnection
 from pyspades.constants import (
@@ -137,6 +137,7 @@ class ServerConnection(BaseConnection):
         self.respawn_time = protocol.respawn_time
         self.rapids = SlidingWindow(RAPID_WINDOW_ENTRIES)
         self.client_info = {}
+        self.proto_extensions = {}  # type: Dict[int, int]
         self.line_build_start_pos = None
 
     def on_connect(self) -> None:
@@ -171,6 +172,10 @@ class ServerConnection(BaseConnection):
         if self.player_id is None:
             return
         call_packet_handler(self, loader)
+
+    @register_packet_handler(loaders.ProtocolExtensionInfo)
+    def on_new_player_recieved(self, contained: loaders.ProtocolExtensionInfo) -> None:
+        self.proto_extensions = dict(contained.extensions)
 
     @register_packet_handler(loaders.ExistingPlayer)
     @register_packet_handler(loaders.ShortPlayerData)
@@ -1026,6 +1031,9 @@ class ServerConnection(BaseConnection):
         self.send_map(ProgressiveMapGenerator(self.protocol.map))
         if not self.client_info:
             self.send_contained(handshake_init)
+        ext_info = loaders.ProtocolExtensionInfo()
+        ext_info.extensions = []
+        self.send_contained(ext_info)
 
     def _send_connection_data(self) -> None:
         saved_loaders = self.saved_loaders = []

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -174,7 +174,7 @@ class ServerConnection(BaseConnection):
         call_packet_handler(self, loader)
 
     @register_packet_handler(loaders.ProtocolExtensionInfo)
-    def on_new_player_recieved(self, contained: loaders.ProtocolExtensionInfo) -> None:
+    def on_ext_info_received(self, contained: loaders.ProtocolExtensionInfo) -> None:
         self.proto_extensions = dict(contained.extensions)
 
     @register_packet_handler(loaders.ExistingPlayer)


### PR DESCRIPTION
This adds support for querying the clients protocol extensions. It
doesn't do anything more, like actually send extensions, handle
extension packets, allow registering handlers for extensions or do
anything useful with the result.