### PR TITLE
tidy dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,12 +62,6 @@ pip (stable version)
 
     pip3 install piqueserver
 
-to install with the optional ssh server
-
-.. code:: bash
-
-    pip3 install piqueserver[ssh]
-
 git (bleeding edge)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/piqueserver/ssh.py
+++ b/piqueserver/ssh.py
@@ -17,15 +17,10 @@
 
 import sys
 from os import path
-try:
-    from twisted.cred import portal, checkers
-    from twisted.conch import manhole, manhole_ssh
-    from twisted.conch.ssh import keys
-except ImportError as e:
-    print("ERROR: piqueserver was not installed with the [ssh] option")
-    print("but SSH was enabled in the settings")
-    print(e)
-    sys.exit(1)
+
+from twisted.cred import portal, checkers
+from twisted.conch import manhole, manhole_ssh
+from twisted.conch.ssh import keys
 
 from piqueserver.config import config
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # core
 Cython>=0.27,<1
-Twisted[tls]>=17
+Twisted[tls]>=17,<19
 Jinja2>=2,<3
 pyenet
 toml
@@ -9,11 +9,7 @@ aiohttp>=3.3.0,<3.6.0
 packaging>=19.0
 
 # from command
-pygeoip>=0.3.2,<0.4
-
-# ssh
-cryptography
-pyasn1
+geoip2>=2.9,<3.0
 
 # windows specific
 pypiwin32; platform_system=="Windows"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # core
 Cython>=0.27,<1
-Twisted[tls]>=17,<19
+Twisted[tls]
 Jinja2>=2,<3
 pyenet
 toml

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ setup(
     install_requires=[
         'pypiwin32;platform_system=="Windows"',
         'Cython>=0.27,<1',
-        'Twisted[tls]>=17,<19',
+        'Twisted[tls]',
         'Jinja2>=2,<3',
         'pypng==0.0.19',
         'aiohttp>=3.3.0,<3.6.0',

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ setup(
         'pypiwin32;platform_system=="Windows"',
         'Cython>=0.27,<1',
         'Twisted[tls]>=17,<19',
-        'Jinja2>=2,<3',  # status server is part of our 'vanilla' package
+        'Jinja2>=2,<3',
         'pypng==0.0.19',
         'aiohttp>=3.3.0,<3.6.0',
         'pyenet',
@@ -146,11 +146,6 @@ setup(
     ],
     extras_require={
         'from': ['geoip2>=2.9,<3.0'],
-        # 'statusserver': ['Jinja2>=2.8,<2.9', 'pypng==0.0.19'],
-        'ssh': [
-            'cryptography>=2.1.4,<2.2',
-            'pyasn1>=0.4.2,<0.5'
-        ]
     },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
ssh deps are included as subdeps of twisted[tls]. additionally, 
the cryptography version we depended on conflicted with the version
required by twisted.

Also bring requirements.txt into line with setup.py