### PR TITLE
Split permissions for moving and moving others

### DIFF
--- a/piqueserver/commands.py
+++ b/piqueserver/commands.py
@@ -405,8 +405,8 @@ def _handle_command(connection, command, parameters):
         msg = 'Command failed'
     except CommandError as e:
         msg = str(e)
-    except PermissionDenied:
-        msg = 'You can\'t use this command'
+    except PermissionDenied as e:
+        msg = 'You can\'t do that: {}'.format(str(e))
     except ValueError:
         msg = 'Invalid parameters'
 

--- a/piqueserver/core_commands/movement.py
+++ b/piqueserver/core_commands/movement.py
@@ -1,5 +1,6 @@
 from pyspades.common import (coordinates, to_coordinates)
-from piqueserver.commands import command, CommandError, get_player
+from piqueserver.commands import (command, CommandError, get_player,
+                                  PermissionDenied)
 
 
 @command(admin_only=True)
@@ -25,6 +26,8 @@ def move_silent(connection, *args):
     If the z coordinate makes the player appear underground, put them at ground level instead.
     If the x/y/z coordinate makes the player appear outside of the world bounds,
     take the bound instead
+
+    You can only move other players if you are admin or have the move_others right
     """
     do_move(connection, args, True)
 
@@ -38,6 +41,8 @@ def move(connection, *args):
     If the z coordinate makes the player appear underground, put them at ground level instead.
     If the x/y/z coordinate makes the player appear outside of the world bounds,
     take the bound instead
+
+    You can only move other players if you are admin or have the move_others right
     """
     if connection not in connection.protocol.players:
         raise ValueError()
@@ -74,6 +79,9 @@ def do_move(connection, args, silent=False):
         player = connection.name
     # player specified
     elif arg_count == 2 or arg_count == 4:
+        if not connection.rights.admin or connection.rights.move_others:
+            raise PermissionDenied(
+                "moving other players requires the move_others right")
         player = args[0]
 
     player = get_player(connection.protocol, player)

--- a/piqueserver/core_commands/movement.py
+++ b/piqueserver/core_commands/movement.py
@@ -79,7 +79,7 @@ def do_move(connection, args, silent=False):
         player = connection.name
     # player specified
     elif arg_count == 2 or arg_count == 4:
-        if not connection.rights.admin or connection.rights.move_others:
+        if not (connection.rights.admin or connection.rights.move_others):
             raise PermissionDenied(
                 "moving other players requires the move_others right")
         player = args[0]

--- a/piqueserver/core_commands/player.py
+++ b/piqueserver/core_commands/player.py
@@ -57,7 +57,7 @@ def kill(connection, value=None):
         player = connection
     else:
         if not connection.rights.kill and not connection.admin:
-            raise PermissionDenied()
+            raise PermissionDenied("you can't kill other players")
         player = get_player(connection.protocol, value, False)
     player.kill()
     if connection is not player:


### PR DESCRIPTION
the move_others or admin right is now required to move other players

closes #474