### PR TITLE
Make Ban Checking Constant Time

### DIFF
--- a/piqueserver/networkdict.py
+++ b/piqueserver/networkdict.py
@@ -1,4 +1,5 @@
 from ipaddress import ip_network, ip_address
+from collections import OrderedDict
 
 def get_cidr(network):
     if network.prefixlen == 32:
@@ -10,7 +11,7 @@ def get_cidr(network):
 
 class NetworkDict(object):
     def __init__(self):
-        self.networks = []
+        self.networks = OrderedDict()
 
     def read_list(self, values):
         for item in values:
@@ -25,46 +26,55 @@ class NetworkDict(object):
     def remove(self, key):
         """remove a key from the networkdict and return the removed items"""
         ip = ip_network(str(key), strict=False)
-        networks = []
         results = []
-        for item in self.networks:
-            network, _value = item
-            if ip in network or ip == network:
-                # this value should be removed
-                results.append(item)
+        # There are 32 possible networks for each IP address in CIDR. This is
+        # small enough that we can just loop through all of them to get an
+        # unelegant constant time lookup for IP addresses.
+        #
+        # This loop could be sped up by a lot by using a (ip, mask) int tuple
+        # instead of constantly creating new IPNetwork objects with .supernet()
+        #
+        # When in doubt, use brute force - Ken Thompson
+        for _ in range(0, 32):
+            try:
+                elem = self.networks.pop(ip)
+            except KeyError:
+                pass
             else:
-                # keep this value in the networkdict
-                networks.append(item)
-        self.networks = networks
+                results.append([ip, elem])
+            ip = ip.supernet()
         return results
 
     def __setitem__(self, key, value):
-        self.networks.append((ip_network(str(key), strict=False), value))
+        self.networks[ip_network(str(key), strict=False)] = value
 
     def __getitem__(self, key):
         return self.get_entry(key)[1]
 
     def get_entry(self, key):
-        ip = ip_address(str(key))
-        for entry in self.networks:
-            network, _value = entry
-            if ip in network:
-                return entry
-        raise KeyError()
+        ip = ip_network(str(key))
+        # See comment for remove()
+        for _ in range(0, 32):
+            try:
+                return self.networks[ip]
+            except KeyError:
+                pass
+            ip = ip.supernet()
+        raise KeyError(key)
 
     def __len__(self):
         return len(self.networks)
 
     def __delitem__(self, key):
         ip = ip_network(str(key), strict=False)
-        self.networks = [item for item in self.networks if ip not in item]
+        self.networks.popitem(ip)
 
     def pop(self, *arg, **kw):
-        network, value = self.networks.pop(*arg, **kw)
+        network, value = self.networks.popitem(*arg, **kw)
         return get_cidr(network), value
 
     def iteritems(self):
-        for network, value in self.networks:
+        for network, value in self.networks.items():
             yield get_cidr(network), value
 
     def __contains__(self, key):

--- a/tests/piqueserver/test_networkdict.py
+++ b/tests/piqueserver/test_networkdict.py
@@ -16,7 +16,6 @@ class TestNetworkDict(unittest.TestCase):
             ["(unknown)", "178.63.171.105", ": Hack", 1511716248.032651],
             ["Ken Kaneki", "177.222.250.65", ": kaneki afk", 1511718856.598152],
             ["panic-recover", "172.17.0.1", ": 10", 1512040137.320614],
-            ["panic-recover", "172.17.0.1", ": who", 1512043319.372366]
         ]
         networkdict = NetworkDict()
         networkdict.read_list(ban_list)


### PR DESCRIPTION
Ban checking is now constant time. This makes ban checking for a small
banlist slower by a factor of 10. However, more importantly, ban
checking now takes the same amount of time regardless of how many bans
you have stored.

 Original Pyspades

10 8.670362993143498e-06
100 5.076720300712623e-05
1000 0.0004664193200005684
10000 0.004667077518010047

 New Constant Time

10 9.937950099993032e-05
100 0.00010137572599342092
1000 0.00010073935400578194
10000 0.00010321205800573807

It would be very easy to make this faster even for lower values.
IPv4Address objects are heavy to create, and we create a bunch of them.
They could be created only when necessary for output, and a faster (ip:
int, mask: int) tuple could be used internally.

However, this commit solves the problem aloha is having and I have to go
now.

closes #158