### PR TITLE
Update bansubscribe format and fix operation

### DIFF
--- a/doc/config-options.rst
+++ b/doc/config-options.rst
@@ -137,7 +137,11 @@ This section defines the behaviour when admins ban players::
     publish_port = 32885
 
     # Bansubscribe allows you to inherit bans from another server with banpublish enabled.
-    urls = [ [ "http://www.blacklist.spadille.net/subscribe.json", []]]
+    # `url` is the URL returning the json list, `whitelist` is a list of names which should
+    # be exempt from the filter
+    bansubscribe = [
+        { url = "http://www.blacklist.spadille.net/subscribe.json", whitelist = []},
+    ]
 
 .. _respawn_waves:
 

--- a/piqueserver/bansubscribe.py
+++ b/piqueserver/bansubscribe.py
@@ -18,16 +18,30 @@
 import json
 from twisted.internet.task import LoopingCall
 from twisted.internet.defer import DeferredList
+from twisted.web.client import getPage
+from twisted.logger import Logger
 
 from piqueserver.networkdict import NetworkDict
 from piqueserver.config import config
+
+log = Logger()
 
 UPDATE_INTERVAL = 5 * 60  # every 5 minute
 
 # format is [{"ip" : "1.1.1.1", "reason : "blah"}, ...]
 
+def validate_bansub_config(c):
+    if not isinstance(c, list):
+        return False
+
+    for item in c:
+        if not item.get('url') or not isinstance(item.get('whitelist'), list):
+            return False
+
+    return True
+
 bans_config = config.section('bans')
-urls = bans_config.option('urls', [])
+bans_config_urls = bans_config.option('bansubscribe', default=[], validate=validate_bansub_config)
 
 class BanManager(object):
     bans = None
@@ -35,8 +49,8 @@ class BanManager(object):
 
     def __init__(self, protocol):
         self.protocol = protocol
-        self.urls = [(str(item), name_filter) for (item, name_filter) in
-                     urls.get()]
+        self.urls = [(entry.get('url'), entry.get('whitelist')) for entry in
+                     bans_config_urls.get()]
         self.loop = LoopingCall(self.update_bans)
         self.loop.start(UPDATE_INTERVAL, now=True)
 
@@ -44,7 +58,7 @@ class BanManager(object):
         self.new_bans = NetworkDict()
         defers = []
         for url, url_filter in self.urls:
-            defers.append(self.protocol.getPage(url).addCallback(self.got_bans,
+            defers.append(getPage(url.encode('utf8')).addCallback(self.got_bans,
                                                                  url_filter))
         DeferredList(defers).addCallback(self.bans_finished)
 
@@ -59,6 +73,7 @@ class BanManager(object):
     def bans_finished(self, _result):
         self.bans = self.new_bans
         self.new_bans = None
+        log.info("successfully updated bans from bansubscribe urls")
 
     def get_ban(self, ip):
         if self.bans is None:

--- a/piqueserver/config.py
+++ b/piqueserver/config.py
@@ -177,6 +177,7 @@ class ConfigStore():
         '''
         Register and return a new option object.
         '''
+        # TODO: how to handle same option defined twice?
         option = _Option(self, name, default, cast, validate)
         self._options[name] = option
         return option
@@ -185,6 +186,9 @@ class ConfigStore():
         '''
         Register and return a new section object.
         '''
+        if name in self._sections:
+            return self._sections[name]
+
         section = _Section(self, name)
         self._sections[name] = section
         return section

--- a/piqueserver/config/config.toml
+++ b/piqueserver/config/config.toml
@@ -212,11 +212,12 @@ default_duration = "1day"
 #publish_port = 32885
 
 # Bansubscribe allows you to inherit bans from another server with banpublish enabled.
-# First element of list is the URL, the second is a list of names which should
+# `url` is the URL returning the json list, `whitelist` is a list of names which should
 # be exempt from the filter
-#urls = [
-#  ["http://www.blacklist.spadille.net/subscribe.json", []]
+#bansubscribe = [
+#    { url = "http://www.blacklist.spadille.net/subscribe.json", whitelist = []},
 #]
+
 
 
 [rights]

--- a/piqueserver/server.py
+++ b/piqueserver/server.py
@@ -55,6 +55,7 @@ from piqueserver.player import FeatureConnection
 from piqueserver.release import check_for_releases, format_release
 from piqueserver.scheduler import Scheduler
 from piqueserver.utils import as_deferred
+from piqueserver.bansubscribe import bans_config_urls
 from pyspades.bytes import NoDataLeft
 from pyspades.constants import CTF_MODE, ERROR_SHUTDOWN, TC_MODE
 from pyspades.master import MAX_SERVER_NAME_SIZE
@@ -394,7 +395,7 @@ class FeatureProtocol(ServerProtocol):
         if ban_publish.get():
             from piqueserver.banpublish import PublishServer
             self.ban_publish = PublishServer(self, ban_publish_port.get())
-        if bans_urls.get():
+        if bans_config_urls.get():
             from piqueserver import bansubscribe
             self.ban_manager = bansubscribe.BanManager(self)
         self.start_time = time.time()


### PR DESCRIPTION
note: changes to config.py are to make sure check_unused works
correctly. probably will need some more tweaks in future too.

This is a backwards incompatible change for the bansubscribe config
format, but it was previously broken anyway, so no-one has probably been
using it.

fixes #524
fixes #519
fixes #483