### PR TITLE
Preserve existing blocks during linebuild

### DIFF
--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -600,6 +600,8 @@ class ServerConnection(BaseConnection):
 
         for point in points:
             x, y, z = point
+            if map_.get_solid(x, y, z):
+                continue
             if not map_.build_point(x, y, z, self.color):
                 break
 


### PR DESCRIPTION
When linebuilding over existing blocks, they will be overwritten serverside but not in the client (in Voxlap or OpenSpades. In BetterSpades, they are also overwritten in the client). This means you will only see the overwritten blocks and the actual result of your linebuild after reconnecting to the server.

I personally think it is a better approach to have existing blocks not being overwritten (also means less issues with modes or scripts relying on custom block protections), therefore this PR. In case someone has good arguments in favor of overwriting blocks, OpenSpades should receive a fix then to directly show the result.

![linebuild](https://user-images.githubusercontent.com/25709784/62822314-d0d05400-bb81-11e9-8f22-32bd556c90de.jpg)
