### PR TITLE
Make bansubscribe interval configurable

### DIFF
--- a/doc/config-options.rst
+++ b/doc/config-options.rst
@@ -124,14 +124,14 @@ bans
 This section defines the behaviour when admins ban players::
 
     [bans]
-    # default duration in minutes a banned player will be banned for
-    default_duration = 1440
+    # default duration a banned player will be banned for
+    default_duration = "1day"
 
     # location the bans are saved and loaded from
     file = "bans.txt"
 
     # Ban publish allows you to synchronize bans between servers. When enabled,
-    # the server listens on the given port and respnds to any requests with a list
+    # the server listens on the given port and responds to any requests with a list
     # of bans
     publish = false
     publish_port = 32885
@@ -142,6 +142,9 @@ This section defines the behaviour when admins ban players::
     bansubscribe = [
         { url = "http://www.blacklist.spadille.net/subscribe.json", whitelist = []},
     ]
+
+    # how often the subscribed servers are frequented to update bans
+    bansubscribe_interval = "5min"
 
 .. _respawn_waves:
 


### PR DESCRIPTION
If a published banlist has low activity or even just a fixed set of bans/rangebans, a forced update every 5 minutes seems unnecessary. This optional parameter "bansubscribe_interval" allows to change it to a custom update interval in the config.toml.