### PR TITLE
Fix checking connection is a player

### DIFF
--- a/piqueserver/core_commands/game.py
+++ b/piqueserver/core_commands/game.py
@@ -28,7 +28,7 @@ def reset_game(connection):
     """
     resetting_player = connection
     # irc compatibility
-    if resetting_player not in connection.protocol.players:
+    if resetting_player not in connection.protocol.players.values():
         for player in connection.protocol.players.values():
             resetting_player = player
             if player.admin:
@@ -78,7 +78,7 @@ def switch(connection, player=None, team=None):
     protocol = connection.protocol
     if player is not None:
         player = get_player(protocol, player)
-    elif connection in protocol.players:
+    elif connection in protocol.players.values():
         player = connection
     else:
         raise ValueError()
@@ -96,7 +96,7 @@ def switch(connection, player=None, team=None):
         player.on_team_changed(old_team)
         player.spawn(player.world_object.position.get())
         player.send_chat('Switched to %s team' % player.team.name)
-        if connection is not player and connection in protocol.players:
+        if connection is not player and connection in protocol.players.values():
             connection.send_chat('Switched %s to %s team' % (player.name,
                                                              player.team.name))
         protocol.irc_say('* %s silently switched teams' % player.name)

--- a/piqueserver/core_commands/info.py
+++ b/piqueserver/core_commands/info.py
@@ -1,14 +1,13 @@
-from piqueserver.commands import command, _commands, has_permission, get_player, get_command_help
+from piqueserver.commands import command, _commands, has_permission, get_player, get_command_help, player_only
 
 
 @command()
+@player_only
 def streak(connection):
     """
     Tell your current kill streak
     /streak
     """
-    if connection not in connection.protocol.players:
-        raise KeyError()
     return ('Your current kill streak is %s. Best is %s kills' %
             (connection.streak, connection.best_streak))
 
@@ -20,7 +19,7 @@ def ping(connection, value=None):
     /ping
     """
     if value is None:
-        if connection not in connection.protocol.players:
+        if connection not in connection.protocol.players.values():
             raise ValueError()
         player = connection
     else:
@@ -32,13 +31,12 @@ def ping(connection, value=None):
 
 
 @command()
+@player_only
 def rules(connection):
     """
     Show you the server rules
     /rules
     """
-    if connection not in connection.protocol.players:
-        raise KeyError()
     lines = connection.protocol.rules
     if lines is None:
         return

--- a/piqueserver/core_commands/moderation.py
+++ b/piqueserver/core_commands/moderation.py
@@ -207,7 +207,7 @@ def ip(connection, value=None):
     /ip [player]
     """
     if value is None:
-        if connection not in connection.protocol.players:
+        if connection not in connection.protocol.players.values():
             raise ValueError()
         player = connection
     else:
@@ -245,7 +245,7 @@ def invisible(connection, player=None):
     protocol = connection.protocol
     if player is not None:
         player = get_player(protocol, player)
-    elif connection in protocol.players:
+    elif connection in protocol.players.values():
         player = connection
     else:
         raise ValueError()
@@ -300,7 +300,7 @@ def invisible(connection, player=None):
         protocol.broadcast_contained(set_color, sender=player, save=True)
         protocol.broadcast_contained(input_data, sender=player)
         protocol.broadcast_contained(weapon_input, sender=player)
-    if connection is not player and connection in protocol.players:
+    if connection is not player and connection in protocol.players.values():
         if player.invisible:
             return '%s is now invisible' % player.name
         else:
@@ -315,7 +315,7 @@ def godsilent(connection, player=None):
     """
     if player is not None:
         connection = get_player(connection.protocol, player)
-    elif connection not in connection.protocol.players:
+    elif connection not in connection.protocol.players.values():
         return 'Unknown player: ' + player
 
     connection.god = not connection.god  # toggle godmode
@@ -351,7 +351,7 @@ def god(connection, player=None):
     """
     if player:
         connection = get_player(connection.protocol, player)
-    elif connection not in connection.protocol.players:
+    elif connection not in connection.protocol.players.values():
         return 'Unknown player'
 
     connection.god = not connection.god  # toggle godmode
@@ -372,7 +372,7 @@ def god_build(connection, player=None):
     protocol = connection.protocol
     if player is not None:
         player = get_player(protocol, player)
-    elif connection in protocol.players:
+    elif connection in protocol.players.values():
         player = connection
     else:
         raise ValueError()
@@ -382,6 +382,6 @@ def god_build(connection, player=None):
     message = ('now placing god blocks' if player.god_build else
                'no longer placing god blocks')
     player.send_chat("You're %s" % message)
-    if connection is not player and connection in protocol.players:
+    if connection is not player and connection in protocol.players.values():
         connection.send_chat('%s is %s' % (player.name, message))
     protocol.irc_say('* %s is %s' % (player.name, message))

--- a/piqueserver/core_commands/player.py
+++ b/piqueserver/core_commands/player.py
@@ -1,4 +1,4 @@
-from piqueserver.commands import command, get_player, PermissionDenied
+from piqueserver.commands import command, get_player, PermissionDenied, player_only
 
 @command("client", "cli")
 def client(connection, target=None):
@@ -31,13 +31,12 @@ def weapon(connection, value):
 
 
 @command()
+@player_only
 def intel(connection):
     """
     Inform you of who has the enemy intel
     /intel
     """
-    if connection not in connection.protocol.players:
-        raise KeyError()
     flag = connection.team.other.flag
     if flag.player is not None:
         if flag.player is connection:
@@ -75,7 +74,7 @@ def heal(connection, player=None):
         player = get_player(connection.protocol, player, False)
         message = '%s was healed by %s' % (player.name, connection.name)
     else:
-        if connection not in connection.protocol.players:
+        if connection not in connection.protocol.players.values():
             raise ValueError()
         player = connection
         message = '%s was healed' % (connection.name)

--- a/piqueserver/core_commands/server.py
+++ b/piqueserver/core_commands/server.py
@@ -21,7 +21,7 @@ def server_name(connection, *arg):
     message = "%s changed servername to '%s'" % (connection.name, name)
     log.info(message)
     connection.protocol.irc_say("* " + message)
-    if connection in connection.protocol.players:
+    if connection in connection.protocol.players.values():
         return message
     return None
 
@@ -73,5 +73,5 @@ def toggle_master(connection):
     message = ("toggled master broadcast %s" % ['OFF', 'ON'][
         int(protocol.master)])
     protocol.irc_say("* %s " % connection.name + message)
-    if connection in connection.protocol.players:
+    if connection in connection.protocol.players.values():
         return "You " + message

--- a/piqueserver/scripts/afk.py
+++ b/piqueserver/scripts/afk.py
@@ -63,7 +63,7 @@ def kick_afk(connection, minutes, amount=None):
         num_connections=amount - kicks,
         time=minutes_s)
     protocol.irc_say('* ' + message)
-    if connection in protocol.players:
+    if connection in protocol.players.values():
         return message
 
 

--- a/piqueserver/scripts/airstrike2.py
+++ b/piqueserver/scripts/airstrike2.py
@@ -17,7 +17,7 @@ from pyspades.contained import GrenadePacket
 from pyspades.common import to_coordinates, Vertex3
 from pyspades.world import Grenade
 from pyspades.constants import UPDATE_FREQUENCY, WEAPON_TOOL
-from piqueserver.commands import command, admin, get_player
+from piqueserver.commands import command, admin, get_player, player_only
 
 STREAK_REQUIREMENT = 8
 
@@ -44,9 +44,8 @@ ARRIVAL_DELAY = 2  # seconds from airstrike notice to arrival
 
 
 @command('airstrike', 'a')
+@player_only
 def airstrike(connection, *args):
-    if connection not in connection.protocol.players:
-        raise ValueError()
     player = connection
 
     if player.airstrike:
@@ -64,7 +63,7 @@ def give_strike(connection, player=None):
     protocol = connection.protocol
     if player is not None:
         player = get_player(protocol, player)
-    elif connection in protocol.players:
+    elif connection in protocol.players.values():
         player = connection
     else:
         raise ValueError()

--- a/piqueserver/scripts/analyze.py
+++ b/piqueserver/scripts/analyze.py
@@ -83,7 +83,7 @@ def apply_script(protocol, connection, config):
                         for name in list(self.protocol.analyzers.keys()):
                             if self.protocol.analyzers[name] == self.name:
                                 analyzer = get_player(self.protocol, name)
-                                if analyzer not in self.protocol.players:
+                                if analyzer not in self.protocol.players.values():
                                     raise ValueError()
                                 else:
                                     if body_part == "HEADSHOT":

--- a/piqueserver/scripts/badmin.py
+++ b/piqueserver/scripts/badmin.py
@@ -1,5 +1,5 @@
 """
-Badmin is an bot admin. 
+Badmin is an bot admin.
 
 It automates common admin tasks such as:
 
@@ -98,7 +98,7 @@ def investigate(connection, player):
 
 def score_grief(connection, player, time=None):  # 302 = blue (0), #303 = green (1)
     print("start score grief")
-    color = connection not in connection.protocol.players and connection.colors
+    color = connection not in connection.protocol.players.values() and connection.colors
     minutes = float(time or 2)
     if minutes < 0.0:
         raise ValueError()

--- a/piqueserver/scripts/blockinfo.py
+++ b/piqueserver/scripts/blockinfo.py
@@ -36,7 +36,7 @@ IRC_ONLY = blockinfo_config.option("irc_only", False)
 def grief_check(connection, player, minutes=2):
     player = get_player(connection.protocol, player)
     protocol = connection.protocol
-    color = connection not in protocol.players and connection.colors
+    color = connection not in protocol.players.values() and connection.colors
     minutes = float(minutes)
     if minutes <= 0.0:
         raise ValueError('minutes must be number greater than 0')

--- a/piqueserver/scripts/geoip.py
+++ b/piqueserver/scripts/geoip.py
@@ -36,7 +36,7 @@ finally:
     def where_from(connection, value=None):
         # Get player IP address
         if value is None:
-            if connection not in connection.protocol.players:
+            if connection not in connection.protocol.players.values():
                 raise ValueError()
             player = connection
         else:

--- a/piqueserver/scripts/markers.py
+++ b/piqueserver/scripts/markers.py
@@ -43,7 +43,7 @@ from pyspades.world import cube_line
 from pyspades.contained import BlockAction, BlockLine, SetColor, ChatMessage
 from pyspades.common import make_color, to_coordinates
 from pyspades.constants import *
-from piqueserver.commands import command, admin, get_player
+from piqueserver.commands import command, admin, get_player, player_only
 
 SHADOW_INTEL = True  # if True, shows where the intel used to be before taken
 REVEAL_ENEMIES = True  # if True, mimics old intel reveal behavior when captured
@@ -73,9 +73,8 @@ ENEMY_EXPIRE_DISTANCE_SQUARED = 18.0 ** 2
 
 
 @command(admin_only=True)
+@player_only
 def clear(connection):
-    if connection not in connection.protocol.players:
-        raise ValueError()
     connection.destroy_markers()
     return S_CLEARED
 
@@ -96,9 +95,8 @@ def toggle_markers(connection, player=None):
 
 
 @command()
+@player_only
 def markers(connection):
-    if connection not in connection.protocol.players:
-        raise ValueError()
     connection.send_lines(S_HELP)
 
 

--- a/piqueserver/scripts/paint.py
+++ b/piqueserver/scripts/paint.py
@@ -24,7 +24,7 @@ def paint(connection, player=None):
     protocol = connection.protocol
     if player is not None:
         player = get_player(protocol, player)
-    elif connection in protocol.players:
+    elif connection in protocol.players.values():
         player = connection
     else:
         raise ValueError()
@@ -33,7 +33,7 @@ def paint(connection, player=None):
 
     message = 'now painting' if player.painting else 'no longer painting'
     player.send_chat("You're %s" % message)
-    if connection is not player and connection in protocol.players:
+    if connection is not player and connection in protocol.players.values():
         connection.send_chat('%s is %s' % (player.name, message))
     protocol.irc_say('* %s is %s' % (player.name, message))
 

--- a/piqueserver/scripts/rapid.py
+++ b/piqueserver/scripts/rapid.py
@@ -28,7 +28,7 @@ def toggle_rapid(connection, player=None):
     protocol = connection.protocol
     if player is not None:
         player = get_player(protocol, player)
-    elif connection in protocol.players:
+    elif connection in protocol.players.values():
         player = connection
     else:
         raise ValueError()
@@ -44,7 +44,7 @@ def toggle_rapid(connection, player=None):
 
     message = 'now rapid' if rapid else 'no longer rapid'
     player.send_chat("You're %s" % message)
-    if connection is not player and connection in protocol.players:
+    if connection is not player and connection in protocol.players.values():
         connection.send_chat('%s is %s' % (player.name, message))
     protocol.irc_say('* %s is %s' % (player.name, message))
 

--- a/piqueserver/scripts/ratio.py
+++ b/piqueserver/scripts/ratio.py
@@ -33,10 +33,10 @@ def ratio(connection, user=None):
     if user is not None:
         connection = get_player(connection.protocol, user)
         msg = "%s has"
-        if connection not in connection.protocol.players:
+        if connection not in connection.protocol.players.values():
             raise KeyError()
         msg %= connection.name
-    if connection not in connection.protocol.players:
+    if connection not in connection.protocol.players.values():
         raise KeyError()
 
     kills = connection.ratio_kills

--- a/piqueserver/scripts/runningman.py
+++ b/piqueserver/scripts/runningman.py
@@ -68,7 +68,7 @@ def unlink(connection, player=None):
 
     if player is not None:
         player = get_player(protocol, player)
-    elif connection in protocol.players:
+    elif connection in protocol.players.values():
         player = connection
     else:
         raise ValueError()

--- a/piqueserver/scripts/votemap.py
+++ b/piqueserver/scripts/votemap.py
@@ -26,7 +26,7 @@ from twisted.internet.task import LoopingCall
 from pyspades.common import prettify_timespan
 from piqueserver.map import check_rotation
 from piqueserver.scheduler import Scheduler
-from piqueserver.commands import command
+from piqueserver.commands import command, player_only
 from piqueserver.config import config, cast_duration
 
 votemap_config = config.section('votemap')
@@ -177,9 +177,8 @@ class VoteMap(object):
 
 
 @command()
+@player_only
 def votemap(connection, *arg):
-    if connection not in connection.protocol.players:
-        raise KeyError()
     if not connection.protocol.votemap_player_driven and not connection.admin:
         return "Player-initiated mapvotes are disabled on this server."
     return connection.protocol.start_votemap(
@@ -187,9 +186,8 @@ def votemap(connection, *arg):
 
 
 @command('vote')
+@player_only
 def votemap_vote(connection, value):
-    if connection not in connection.protocol.players:
-        raise KeyError()
     if connection.protocol.votemap is not None:
         return connection.protocol.votemap.vote(connection, value)
     else:


### PR DESCRIPTION
Removal of MultiKeyDict broke everything. This should help unbreak
things. Builds on @notafile's player_only decorator and discussion on
matrix.

Note that I've probably missed some cases - it's very pervasive.

Also need to check in each case that is updated that it actually makes
sense. In same cases we want to check the keys, not the values, because
we're looking for player_ids rather than connection objects.