### PR TITLE
Improve ban entry error

### DIFF
--- a/piqueserver/networkdict.py
+++ b/piqueserver/networkdict.py
@@ -9,12 +9,15 @@ def get_cidr(network):
 # Note: Network objects cannot have any host bits set without strict=False.
 # More info: https://docs.python.org/3/howto/ipaddress.html#defining-networks
 
+
 class NetworkDict(object):
     def __init__(self):
         self.networks = OrderedDict()
 
     def read_list(self, values):
-        for item in values:
+        for index, item in enumerate(values):
+            if len(item) < 4:
+                raise ValueError("Invalid ban entry. index: {} item: {}\nEntry format needs to be [name, ip, reason, time]".format(index, item))
             self[item[1]] = [item[0]] + item[2:]
 
     def make_list(self):


### PR DESCRIPTION
```
2019-08-19T12:53:17+0530 [piqueserver.server#error] Could not parse bans file (bans.txt): Invalid ban entry. index: 0 item: ['panic-recover', '172.17.0.1', ': 10']
        Entry format needs to be [name, ip, reason, time]

```

Closes: #531 