### PR TITLE
Revert 'Replace Pillow with pypng'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ COPY requirements.txt /usr/src/app/
 # Note: manylinux wheel support isn't enabled by default for alpinelinux
 # we temporarly enable it for pyenet since it is compatible
 RUN apk add --no-cache --virtual .build-deps-cython gcc musl-dev \
-    && apk add --no-cache --virtual .build-deps-crypto libffi-dev openssl-dev \
+    && apk add --no-cache --virtual .build-deps-pillow zlib-dev jpeg-dev libffi-dev openssl-dev \
+    && apk add --no-cache zlib jpeg \
     \
     && echo "manylinux1_compatible = True" > /usr/local/lib/python3.6/_manylinux.py \
     && pip install pyenet \
@@ -19,7 +20,7 @@ RUN apk add --no-cache --virtual .build-deps-cython gcc musl-dev \
     && pip install --no-cache-dir -r requirements.txt \
     \
     && apk del .build-deps-cython \
-    && apk del .build-deps-crypto
+    && apk del .build-deps-pillow
 
 # The fact that we removed gcc beforehand makes us download it again
 # This is remedied by building the server core first and leaving all .py scripts 

--- a/piqueserver/statusserver.py
+++ b/piqueserver/statusserver.py
@@ -24,7 +24,7 @@ from multidict import MultiDict
 from jinja2 import Environment, PackageLoader
 import json
 import time
-import png
+from PIL import Image
 from io import BytesIO
 from aiohttp.abc import AbstractAccessLogger
 from twisted.logger import Logger
@@ -117,9 +117,9 @@ class StatusServer(object):
     def update_cached_overview(self):
         """Updates cached overview"""
         overview = self.protocol.map.get_overview(rgba=True)
-        w = png.Writer(512, 512, alpha=True)
+        image = Image.frombytes('RGBA', (512, 512), overview)
         data = BytesIO()
-        w.write_array(data, overview)
+        image.save(data, 'png')
         self.cached_overview = data.getvalue()
         self.last_update = time.time()
         self.last_map_name = self.protocol.map_info.name

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Cython>=0.27,<1
 Jinja2>=2,<3
 pyenet
 toml
-pypng==0.0.20
+Pillow>=5.1.0,<6
 aiohttp>=3.3.0,<3.7.0
 packaging>=19.0
 

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,7 @@ setup(
         'Cython>=0.27,<1',
         'Twisted[tls]',
         'Jinja2>=2,<3',
-        'pypng==0.0.20',
+        'Pillow>=5.1.0,<6',
         'aiohttp>=3.3.0,<3.7.0',
         'pyenet',
         'toml',


### PR DESCRIPTION
That commit broke overview on status page. PyPNG's API doesn't have anything that suits `get_overview`'s output, I should have paid more attention to the docs back then.