### PR TITLE
0.76 support

### DIFF
--- a/pyspades/collision.py
+++ b/pyspades/collision.py
@@ -15,29 +15,37 @@
 # You should have received a copy of the GNU General Public License
 # along with pyspades.  If not, see <http://www.gnu.org/licenses/>.
 
+"""
+Collision-related 3D vector functions.
+"""
+
 import math
+from typing import Any, Tuple
 
 
-def vector_collision(vec1, vec2, distance=3):
+def vector_collision(vec1: Any, vec2: Any, distance: int = 3) -> bool:
     return (math.fabs(vec1.x - vec2.x) < distance and
             math.fabs(vec1.y - vec2.y) < distance and
             math.fabs(vec1.z - vec2.z) < distance)
 
 
-def collision_3d(x1, y1, z1, x2, y2, z2, distance=3):
+def collision_3d(x1: float, y1: float, z1: float,
+                 x2: float, y2: float, z2: float,
+                 distance: int = 3) -> bool:
     return (math.fabs(x1 - x2) < distance and
             math.fabs(y1 - y2) < distance and
             math.fabs(z1 - z2) < distance)
 
 
-def distance_3d_vector(vector1, vector2):
-    xd = vector1.x - vector2.x
-    yd = vector1.y - vector2.y
-    zd = vector1.z - vector2.z
+def distance_3d_vector(vector1: Any, vector2: Any) -> float:
+    xd = vector1.x - vector2.x # type: float
+    yd = vector1.y - vector2.y # type: float
+    zd = vector1.z - vector2.z # type: float
     return math.sqrt(xd**2 + yd**2 + zd**2)
 
 
-def distance_3d(xyz1, xyz2):
+def distance_3d(xyz1: Tuple[float, float, float],
+                xyz2: Tuple[float, float, float]) -> float:
     (x1, y1, z1) = xyz1
     (x2, y2, z2) = xyz2
     xd = x1 - x2

--- a/pyspades/constants.py
+++ b/pyspades/constants.py
@@ -16,7 +16,6 @@
 # along with pyspades.  If not, see <http://www.gnu.org/licenses/>.
 
 MASTER_VERSION = 31
-GAME_VERSION = 3
 RIFLE_WEAPON, SMG_WEAPON, SHOTGUN_WEAPON = range(3)
 TORSO, HEAD, ARMS, LEGS, MELEE = range(5)
 SPADE_TOOL, BLOCK_TOOL, WEAPON_TOOL, GRENADE_TOOL = range(4)
@@ -79,3 +78,38 @@ WEAPON_INTERVAL = {
     SMG_WEAPON: 0.05,
     SHOTGUN_WEAPON: 0.3
 }
+
+# Game version IDs.
+#
+(
+    GAME_VERSION_AOS_075,
+    GAME_VERSION_AOS_076RC10,
+
+    GAME_VERSION_COUNT,
+) = range(2+1)
+
+# Mapping of game versions to protocol versions.
+#
+# AoS since version 0.75 has used an increasing single-integer
+# protocol version number.
+#
+# AoS 0.70 and older use a CRC-32 of the client.exe binary.
+#
+# Some prerelease versions of 0.75:
+# - 0o075001: Not known. Possibly a test candidate version.
+#             Yes, that's an octal number.
+# - 1: 0.75RC12 and some older versions.
+# - 2: Some later release candidate.
+#
+# 0.76 seems to have stuck with version 4 as it was never
+# officially released as the mainline version.
+#
+GAME_PROTOCOL_VERSIONS = {
+    GAME_VERSION_AOS_075: 3,
+    GAME_VERSION_AOS_076RC10: 4,
+}
+
+# Current game version.
+# TODO: Drop the use of this constant and get this from the config.
+GAME_VERSION = GAME_VERSION_AOS_075
+#GAME_VERSION = GAME_VERSION_AOS_076RC10

--- a/pyspades/loaders.pyx
+++ b/pyspades/loaders.pyx
@@ -15,7 +15,14 @@
 # You should have received a copy of the GNU General Public License
 # along with pyspades.  If not, see <http://www.gnu.org/licenses/>.
 
+from pyspades.constants import GAME_VERSION_AOS_075
+from pyspades.constants import GAME_VERSION_COUNT
+
+
 cdef class Loader:
+    since_version = GAME_VERSION_AOS_075
+    until_version = GAME_VERSION_COUNT
+
     def __init__(self, ByteReader reader = None):
         if reader is not None:
             self.read(reader)

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -111,6 +111,7 @@ class ServerConnection(BaseConnection):
         BaseConnection.__init__(self, *arg, **kw)
         protocol = self.protocol
         address = self.peer.address
+        self.game_version = self.protocol.version
         self.total_blocks_removed = 0
         self.address = (address.host, address.port)
         self.respawn_time = protocol.respawn_time
@@ -122,7 +123,8 @@ class ServerConnection(BaseConnection):
     def on_connect(self) -> None:
         if self.local:
             return
-        if self.peer.eventData != self.protocol.version:
+        protocol_version = GAME_PROTOCOL_VERSIONS[self.game_version]
+        if self.peer.eventData != protocol_version:
             log.debug("{player} kicked: wrong protocol version {version}",
                       player=self, version=self.peer.eventData)
             self.disconnect(ERROR_WRONG_VERSION)
@@ -993,7 +995,7 @@ class ServerConnection(BaseConnection):
         self.weapon = weapon
         if self.weapon_object is not None:
             self.weapon_object.reset()
-        weapon_class = get_weapon_class_by_id(weapon)
+        weapon_class = get_weapon_class_by_id(weapon, version=self.game_version)
         self.weapon_object = weapon_class(self._on_reload)
         if not local:
             change_weapon = loaders.ChangeWeapon()

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -29,7 +29,7 @@ from pyspades.mapgenerator import ProgressiveMapGenerator
 from pyspades.packet import call_packet_handler, register_packet_handler
 from pyspades.protocol import BaseConnection
 from pyspades.team import Team
-from pyspades.weapon import WEAPONS
+from pyspades.weapon import get_weapon_class_by_id
 
 log = Logger()
 
@@ -993,7 +993,8 @@ class ServerConnection(BaseConnection):
         self.weapon = weapon
         if self.weapon_object is not None:
             self.weapon_object.reset()
-        self.weapon_object = WEAPONS[weapon](self._on_reload)
+        weapon_class = get_weapon_class_by_id(weapon)
+        self.weapon_object = weapon_class(self._on_reload)
         if not local:
             change_weapon = loaders.ChangeWeapon()
             self.protocol.send_contained(change_weapon, save=True)

--- a/pyspades/server.py
+++ b/pyspades/server.py
@@ -23,6 +23,7 @@ from pyspades.protocol import BaseProtocol
 from pyspades.constants import (
     CTF_MODE, TC_MODE, GAME_VERSION, MIN_TERRITORY_COUNT, MAX_TERRITORY_COUNT,
     UPDATE_FREQUENCY, UPDATE_FPS, NETWORK_FPS)
+from pyspades.constants import GAME_PROTOCOL_VERSIONS
 from pyspades.types import IDPool
 from pyspades.master import get_master_connection
 from pyspades.team import Team
@@ -240,7 +241,12 @@ class ServerProtocol(BaseProtocol):
                 position = (0.0, 0.0, 0.0)
                 orientation = (0.0, 0.0, 0.0)
             items.append((position, orientation))
-        world_update = loaders.WorldUpdate()
+
+        if self.version >= loaders.WorldUpdate076.since_version:
+            world_update = loaders.WorldUpdate076()
+        else:
+            world_update = loaders.WorldUpdate()
+
         # we only want to send as many items of the player list as needed, so
         # we slice it off at the highest player id
         world_update.items = items[:highest_player_id+1]

--- a/pyspades/weapon.py
+++ b/pyspades/weapon.py
@@ -9,6 +9,8 @@ from twisted.internet import reactor # type: ignore
 import pyspades.collision
 from pyspades.constants import (RIFLE_WEAPON, SMG_WEAPON, SHOTGUN_WEAPON,
                                 HEAD, TORSO, ARMS, LEGS, CLIP_TOLERANCE)
+from pyspades.constants import GAME_VERSION_AOS_075
+from pyspades.constants import GAME_VERSION_AOS_076RC10
 
 
 class BaseWeapon(metaclass=ABCMeta):
@@ -293,21 +295,23 @@ class Shotgun076(BaseWeapon076):
     }
 
 
-# 0.75 weapon set
-WEAPONS_075 = {
-    RIFLE_WEAPON: Rifle075,
-    SMG_WEAPON: SMG075,
-    SHOTGUN_WEAPON: Shotgun075,
-}
+WEAPONS_BY_VERSION = {
+    # 0.75 weapon set
+    GAME_VERSION_AOS_075: {
+        RIFLE_WEAPON: Rifle075,
+        SMG_WEAPON: SMG075,
+        SHOTGUN_WEAPON: Shotgun075,
+    },
 
-# 0.76 weapon set
-WEAPONS_076 = {
-    RIFLE_WEAPON: Rifle076,
-    SMG_WEAPON: SMG076,
-    SHOTGUN_WEAPON: Shotgun076,
+    # 0.76 weapon set
+    GAME_VERSION_AOS_076RC10: {
+        RIFLE_WEAPON: Rifle076,
+        SMG_WEAPON: SMG076,
+        SHOTGUN_WEAPON: Shotgun076,
+    },
 }
 
 
 # Currently used weapon set
-def get_weapon_class_by_id(weapon_id: int) -> Type[BaseWeapon]:
-    return WEAPONS_075[weapon_id]
+def get_weapon_class_by_id(weapon_id: int, version: int) -> Type[BaseWeapon]:
+    return WEAPONS_BY_VERSION[version][weapon_id]

--- a/pyspades/weapon.py
+++ b/pyspades/weapon.py
@@ -264,5 +264,7 @@ WEAPONS_076 = {
     SHOTGUN_WEAPON: Shotgun076,
 }
 
+
 # Currently used weapon set
-WEAPONS = WEAPONS_075
+def get_weapon_class_by_id(weapon_id: int) -> BaseWeapon:
+    return WEAPONS_075[weapon_id]


### PR DESCRIPTION
Currently a WIP.

This adds support for the 0.76 protocol. There's also some cleanups of the weapon stuff as we're doing a lot of stuff to pyspades/weapons.py here anyway.

A goal is to eventually be able to have clients speaking different protocols at the same time, which will be useful for a potential overhaul of the protocol as it stands. I don't promise that it will be a good idea to run any pair of protocol or game versions at the same time, but 0.75 and 0.76RC10 should be close enough to each other gameplaywise to not be absolutely awful.