### PR TITLE
World update improvements

### DIFF
--- a/pyspades/protocol.py
+++ b/pyspades/protocol.py
@@ -89,7 +89,7 @@ class BaseProtocol:
             raise IOError("Failed  to Create Enet Host. Is the Port in use?")
 
         self.host.compress_with_range_coder()
-        self.update_loop = asyncio.get_event_loop().call_later(update_interval, self.update)
+        self.update_loop = asyncio.ensure_future(self.update())
         self.connections = {}
         self.clients = {}
 

--- a/pyspades/protocol.py
+++ b/pyspades/protocol.py
@@ -15,8 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with pyspades.  If not, see <http://www.gnu.org/licenses/>.
 
+import asyncio
 from twisted.internet import reactor
-from twisted.internet.task import LoopingCall
 from pyspades.bytes import ByteWriter
 
 import enet
@@ -89,8 +89,7 @@ class BaseProtocol:
             raise IOError("Failed  to Create Enet Host. Is the Port in use?")
 
         self.host.compress_with_range_coder()
-        self.update_loop = LoopingCall(self.update)
-        self.update_loop.start(update_interval, False)
+        self.update_loop = asyncio.get_event_loop().call_later(update_interval, self.update)
         self.connections = {}
         self.clients = {}
 

--- a/pyspades/server.py
+++ b/pyspades/server.py
@@ -103,8 +103,8 @@ class ServerProtocol(BaseProtocol):
                             abs(vec[1] * 1.02) +
                             abs(vec[2] * 1.01))
 
-        self.world_time = time.time()
-        self.loop_lag = time.time()
+        self.world_time = time.monotonic()
+        self.loop_lag = time.monotonic()
 
 
     def _create_teams(self):
@@ -223,32 +223,32 @@ class ServerProtocol(BaseProtocol):
         return entities
 
     def update(self):
-        lag = time.time() - self.loop_lag
+        lag = time.monotonic() - self.loop_lag
         #if lag > (UPDATE_FREQUENCY*1.05):
         #    print("MAIN LOOP UPDATE LAG: " + str(round(lag*1000)) + " ms")
-        self.wu_lag = time.time()
+        self.wu_lag = time.monotonic()
 
         BaseProtocol.update(self)
         for player in self.connections.values():
             if (player.map_data is not None and
                     not player.peer.reliableDataInTransit):
                 player.continue_map_transfer()
-        if (time.time() - self.world_time) > UPDATE_FREQUENCY:
+        if (time.monotonic() - self.world_time) > UPDATE_FREQUENCY:
             self.update_network(True)
-        while (time.time() - self.world_time) > UPDATE_FREQUENCY:
+        while (time.monotonic() - self.world_time) > UPDATE_FREQUENCY:
             self.world.update(UPDATE_FREQUENCY)
             self.on_world_update()
             self.world_time += UPDATE_FREQUENCY
-        if (time.time() - self.last_network_update) >= (1 / NETWORK_FPS):
+        if (time.monotonic() - self.last_network_update) >= (1 / NETWORK_FPS):
             self.update_network(False)
-            self.last_network_update = time.time()        
+            self.last_network_update = time.monotonic()
 
-        self.loop_lag = time.time()
-        lag = time.time() - self.wu_lag
+        self.loop_lag = time.monotonic()
+        lag = time.monotonic() - self.wu_lag
         #if lag > (UPDATE_FREQUENCY / 2):
         #    print("WORLD UPDATE LAG: " + str(round(lag*1000)) + " ms")
 
-        tmp = min(self.world_time+UPDATE_FREQUENCY-time.time(), self.last_network_update+(1 / NETWORK_FPS)-time.time())
+        tmp = min(self.world_time+UPDATE_FREQUENCY-time.monotonic(), self.last_network_update+(1 / NETWORK_FPS)-time.monotonic())
         tmp = max(0, tmp*0.6)
         asyncio.get_event_loop().call_later(tmp, self.update)
         

--- a/pyspades/server.py
+++ b/pyspades/server.py
@@ -224,6 +224,7 @@ class ServerProtocol(BaseProtocol):
     async def update(self):
         while True:
             start_time = time.monotonic()
+            # Notify if update starts more than 4ms later than requested
             lag = start_time - self.world_time - UPDATE_FREQUENCY
             if lag > 0.004:
                 log.debug("LAG before world update: {lag:.0f} ms", lag=lag * 1000)
@@ -248,6 +249,7 @@ class ServerProtocol(BaseProtocol):
                 self.last_network_update = self.world_time
                 self.update_network()
 
+            # Notify if update uses more than 70% of time budget
             lag = time.monotonic() - start_time
             if lag > (UPDATE_FREQUENCY * 0.7):
                 log.debug("world update LAG: {lag:.0f} ms", lag=lag * 1000)

--- a/pyspades/server.py
+++ b/pyspades/server.py
@@ -226,7 +226,7 @@ class ServerProtocol(BaseProtocol):
             start_time = time.monotonic()
             lag = start_time - self.world_time - UPDATE_FREQUENCY
             if lag > 0.004:
-                log.debug("LAG before world update: " + str(round(lag*1000)) + " ms")
+                log.debug("LAG before world update: {lag:.0f} ms", lag=lag * 1000)
 
             BaseProtocol.update(self)
             # Map transfer
@@ -250,7 +250,7 @@ class ServerProtocol(BaseProtocol):
 
             lag = time.monotonic() - start_time
             if lag > (UPDATE_FREQUENCY * 0.7):
-                log.debug("world update LAG: " + str(round(lag*1000)) + " ms")
+                log.debug("world update LAG: {lag:.0f} ms", lag=lag * 1000)
 
             delay = self.world_time + UPDATE_FREQUENCY - time.monotonic()
             await asyncio.sleep(delay)

--- a/pyspades/server.py
+++ b/pyspades/server.py
@@ -247,7 +247,7 @@ class ServerProtocol(BaseProtocol):
                 self.update_network()
 
             lag = time.monotonic() - start_time
-            if lag > (UPDATE_FREQUENCY / 10):
+            if lag > (UPDATE_FREQUENCY * 0.7):
                 log.debug("world update LAG: " + str(round(lag*1000)) + " ms")
 
             delay = self.world_time + UPDATE_FREQUENCY - time.monotonic()

--- a/pyspades/server.py
+++ b/pyspades/server.py
@@ -21,6 +21,7 @@ from itertools import product
 import enet
 import time
 import asyncio
+import traceback
 
 from pyspades.protocol import BaseProtocol
 from pyspades.constants import (
@@ -235,7 +236,10 @@ class ServerProtocol(BaseProtocol):
             # Update world
             while (time.monotonic() - self.world_time) > UPDATE_FREQUENCY:
                 self.world.update(UPDATE_FREQUENCY)
-                self.on_world_update()
+                try:
+                    self.on_world_update()
+                except Exception:
+                    traceback.print_exc()
                 self.world_time += UPDATE_FREQUENCY
             # Update network
             if time.monotonic() - self.last_network_update >= 1 / NETWORK_FPS:

--- a/pyspades/server.py
+++ b/pyspades/server.py
@@ -103,6 +103,7 @@ class ServerProtocol(BaseProtocol):
                             abs(vec[2] * 1.01))
 
         self.last_network_update = self.world_time = time.monotonic()
+        self.loop_count = 0
 
 
     def _create_teams(self):
@@ -235,6 +236,7 @@ class ServerProtocol(BaseProtocol):
                     player.continue_map_transfer()
             # Update world
             while (time.monotonic() - self.world_time) > UPDATE_FREQUENCY:
+                self.loop_count += 1
                 self.world.update(UPDATE_FREQUENCY)
                 try:
                     self.on_world_update()


### PR DESCRIPTION
Now the world update cycle will take into account delays and adjust the physics update. It eliminates most microteleportations of players when the server is busy (for example, when someone downloads a map).
Also increased the number of world_update packages for spectators. Now, if you observe another player in the first person, then the picture is much nicer as it does not twitch.
I tested these changes on my babel+ server for half a year. I did not reveal any problems, the benefits are tangible.