### PR TITLE
Fix set_orientation speedhack

### DIFF
--- a/pyspades/world.pyx
+++ b/pyspades/world.pyx
@@ -169,6 +169,7 @@ cdef class Character(Object):
     def set_orientation(self, x, y, z):
         """set the current orientation of the Player"""
         cdef Vertex3 v = Vertex3(x, y, z)
+        v.normalize()
         reorient_player(self.player, v.value)
 
     cpdef int can_see(self, float x, float y, float z):


### PR DESCRIPTION
We have already discussed this in #532 and chat. A drop in the sea of struggle with cheaters. But a little useful for bots.
`bot.world_object.set_orientation(*(target-pos).get())`
Now such a simple rotation of the bot will give him an normal speed.

In any case, this fix does not break anything. `set_orientation` is called only in `on_orientation_update_recieved`