### PR TITLE
Catch more errors in check_for_releases

### DIFF
--- a/piqueserver/release.py
+++ b/piqueserver/release.py
@@ -30,11 +30,10 @@ async def check_for_releases() -> Optional[Dict[str, Any]]:
     log.debug("checking latest version")
     try:
         release = await fetch_latest_release()
-    except IOError as e:
+        latest_version = release["tag_name"]
+    except Exception as e:
         log.warn("could not fetch latest version: {err}", err=e)
         return None
-
-    latest_version = release["tag_name"]
     if version.parse(latest_version) > version.parse(__version__):
         return release
     return None


### PR DESCRIPTION
```
...
File "piqueserver/server.py", line 728, in watch_for_releases
      self.new_release = await check_for_releases()
File "piqueserver/release.py", line 37, in check_for_releases
      latest_version = release["tag_name"]
builtins.KeyError: 'tag_name'
```
Sometimes it happens. There may be network problems.