### PR TITLE
Consider protocol.tips may be empty

### DIFF
--- a/piqueserver/server.py
+++ b/piqueserver/server.py
@@ -446,7 +446,7 @@ class FeatureProtocol(ServerProtocol):
         """called after the map has been loaded"""
         self.update_format()
         self.tip_frequency = tip_frequency.get()
-        if self.tips is not None and self.tip_frequency > 0:
+        if self.tips is not None and self.tips and self.tip_frequency > 0:
             reactor.callLater(self.tip_frequency * 60, self.send_tip)
 
         self.master = register_master_option.get()

--- a/piqueserver/server.py
+++ b/piqueserver/server.py
@@ -446,7 +446,7 @@ class FeatureProtocol(ServerProtocol):
         """called after the map has been loaded"""
         self.update_format()
         self.tip_frequency = tip_frequency.get()
-        if self.tips is not None and self.tips and self.tip_frequency > 0:
+        if self.tips and self.tip_frequency > 0:
             reactor.callLater(self.tip_frequency * 60, self.send_tip)
 
         self.master = register_master_option.get()


### PR DESCRIPTION
Fix this:
```
File "piqueserver/server.py", line 851, in send_tip
    line = self.tips[random.randrange(len(self.tips))]
File "/usr/lib/python3.5/random.py", line 195, in randrange
    raise ValueError("empty range for randrange()")
ValueError: empty range for randrange()
```
