### PR TITLE
fix line_build_start_pos can be None

### DIFF
--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -561,6 +561,8 @@ class ServerConnection(BaseConnection):
     def on_block_line_recieved(self, contained):
         if not self.hp:
             return  # dead players can't build
+        if self.line_build_start_pos is None:
+            return
 
         map_ = self.protocol.map
 


### PR DESCRIPTION
```
 Traceback (most recent call last):
   File "pyspades/protocol.py", line 170, in update
     self.data_received(peer, event.packet)
   File "piqueserver/server.py", line 830, in data_received
     ServerProtocol.data_received(self, peer, packet)
   File "pyspades/protocol.py", line 122, in data_received
     connection.loader_received(packet)
   File "pyspades/player.py", line 153, in loader_received
     call_packet_handler(self, loader)
   File "pyspades/packet.pyx", line 131, in pyspades.packet.call_packet_handler
     handler(self, contained)


   File "pyspades/player.py", line 584, in on_block_line_recieved
     if not collision_3d(start_pos.x, start_pos.y, start_pos.z, x1, y1, z1,
 AttributeError: 'NoneType' object has no attribute 'x'
```
I don’t understand how this could happen.

UPD: Mb network delay and the player put the first one block with the right button? So the BlockLine package came before WeaponInput.