### PR TITLE
Fix of a player name

### DIFF
--- a/piqueserver/player.py
+++ b/piqueserver/player.py
@@ -193,7 +193,7 @@ class FeatureConnection(ServerConnection):
                 "You can't kill anyone right now! Damage is turned OFF")
             return False
         if not self.killing:
-            self.send_chat("%s. You can't kill anyone." % player.name)
+            self.send_chat("%s. You can't kill anyone." % self.name)
             return False
         elif player.god:
             if not player.invisible:


### PR DESCRIPTION
Invisible players should be addressed with their name instead of the name of the person they are shooting