### PR TITLE
increase can_see distance limit to 128

### DIFF
--- a/pyspades/world_c.cpp
+++ b/pyspades/world_c.cpp
@@ -237,8 +237,8 @@ long can_see(MapData *map, float x0, float y0, float z0, float x1, float y1,
     ftol(f.y * g.x - f.x * g.y, &p.z);
     ftol(g.z, &i.z);
 
-    if (cnt > 32)
-        cnt = 32;
+    if (cnt > 128)
+        cnt = 128;
     while (cnt)
     {
         if (((p.x | p.y) >= 0) && (a.z != c.z))


### PR DESCRIPTION
This function is only used in nointelonwalls and nospadingwalls scripts. That is, the distance does not really exceed 32 blocks. In fact, even less.
And also used in calculating grenade damage. Which never exceeds 16 blocks.
Therefore, this fix does not change anything for the current codebase. However, now the name is true. And it will help my script against esp a lot.