### PR TITLE
Bugfix of inability to load from config - onectf.py

### DIFF
--- a/piqueserver/game_modes/onectf.py
+++ b/piqueserver/game_modes/onectf.py
@@ -53,14 +53,14 @@ def apply_script(protocol, connection, config):
             self.one_ctf = self.reverse_one_ctf = False
             self.one_ctf_spawn_pos = FLAG_SPAWN_POS
             extensions = self.map_info.extensions
-            if ONE_CTF_MODE == ONE_CTF:
+            if "one_ctf" in extensions:
+                self.one_ctf = extensions['one_ctf']
+            elif not self.one_ctf and 'reverse_one_ctf' in extensions:
+                self.reverse_one_ctf = extensions['reverse_one_ctf']
+            elif ONE_CTF_MODE == ONE_CTF:
                 self.one_ctf = True
             elif ONE_CTF_MODE == REVERSE_ONE_CTF:
                 self.reverse_one_ctf = True
-            elif "one_ctf" in extensions:
-                self.one_ctf = extensions['one_ctf']
-            if not self.one_ctf and 'reverse_one_ctf' in extensions:
-                self.reverse_one_ctf = extensions['reverse_one_ctf']
             if 'one_ctf_spawn_pos' in extensions:
                 self.one_ctf_spawn_pos = extensions['one_ctf_spawn_pos']
             return protocol.on_map_change(self, map)


### PR DESCRIPTION
**Describe the bug**
 In the script "piqueserver.game_modes.onectf" you cannot load the selected mode from the config. The default is REVERSE_ONE_CTF.

**To Reproduce**
Steps to reproduce the behavior:
1. select game mode "piqueserver.game_modes.onectf"
2. add the line "extensions = { 'one_ctf': True }" to the txt file for the map
3. run piqueserver
4. take intel and see the message REVERSE_ONE_CTF_MESSAGE = 'Take the intel to the enemy base to score.'

**Additional context**
https://github.com/piqueserver/piqueserver/blob/master/piqueserver/game_modes/onectf.py#L18 
ONE_CTF_MODE = REVERSE_ONE_CTF

https://github.com/piqueserver/piqueserver/blob/master/piqueserver/game_modes/onectf.py#L58
will always exit here without reading config