### PR TITLE
Check distance in hitpacket handler

### DIFF
--- a/piqueserver/scripts/analyze.py
+++ b/piqueserver/scripts/analyze.py
@@ -61,7 +61,7 @@ def apply_script(protocol, connection, config):
         prev_time = None
         body_part = ""
 
-        def on_hit(self, hit_amount, hit_player, type, grenade):
+        def on_unvalidated_hit(self, hit_amount, hit_player, type, grenade):
             if self.name in list(self.protocol.analyzers.values()):
                 if type == HEADSHOT_KILL or hit_amount in body_damage_values or hit_amount in limb_damage_values:
                     if not grenade:
@@ -101,7 +101,7 @@ def apply_script(protocol, connection, config):
                                     else:
                                         analyzer.send_chat('%s shot %s dist: %d blocks dT: NA %s %s(%d)' % (
                                             self.name, hit_player.name, dist, weap, body_part, counter))
-            return connection.on_hit(self, hit_amount, hit_player, type, grenade)
+            return connection.on_unvalidated_hit(self, hit_amount, hit_player, type, grenade)
 
         def on_weapon_set(self, value):
             if self.name in list(self.protocol.analyzers.values()):

--- a/pyspades/constants.py
+++ b/pyspades/constants.py
@@ -44,6 +44,8 @@ SPAWN_RADIUS = 32
 MINE_RANGE = 3
 BUILD_TOLERANCE = 5
 
+FOG_DISTANCE = 128.0
+
 MELEE_DISTANCE = 3
 
 MAX_CHAT_SIZE = 90  # more like 95, but just to make sure

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -385,12 +385,6 @@ class ServerConnection(BaseConnection):
                 return
             hit_amount = self.protocol.melee_damage
         else:
-            # only calculate distance on XY plane -- fog is a cylinder
-            # add rubberband distance to give laggy players leeway
-            dx = position1.x - position2.x
-            dy = position1.y - position2.y
-            if math.sqrt(dx * dx + dy * dy) > FOG_DISTANCE + self.rubberband_distance:
-                return
             hit_amount = self.weapon_object.get_damage(
                 value, position1, position2)
         if is_melee:
@@ -404,6 +398,13 @@ class ServerConnection(BaseConnection):
             return
         elif returned is not None:
             hit_amount = returned
+        if not is_melee:
+            # only calculate distance on XY plane -- fog is a cylinder
+            # add rubberband distance to give laggy players leeway
+            dx = position1.x - position2.x
+            dy = position1.y - position2.y
+            if math.sqrt(dx * dx + dy * dy) > FOG_DISTANCE + self.rubberband_distance:
+                return
         player.hit(hit_amount, self, kill_type)
 
     @register_packet_handler(loaders.GrenadePacket)

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -374,7 +374,8 @@ class ServerConnection(BaseConnection):
         except KeyError:
             return
         valid_hit = world_object.validate_hit(player.world_object,
-                                              value, HIT_TOLERANCE)
+                                              value, HIT_TOLERANCE,
+                                              self.rubberband_distance)
         if not valid_hit:
             return
         position1 = world_object.position
@@ -398,13 +399,6 @@ class ServerConnection(BaseConnection):
             return
         elif returned is not None:
             hit_amount = returned
-        if not is_melee:
-            # only calculate distance on XY plane -- fog is a cylinder
-            # add rubberband distance to give laggy players leeway
-            dx = position1.x - position2.x
-            dy = position1.y - position2.y
-            if math.sqrt(dx * dx + dy * dy) > FOG_DISTANCE + self.rubberband_distance:
-                return
         player.hit(hit_amount, self, kill_type)
 
     @register_packet_handler(loaders.GrenadePacket)

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -20,8 +20,8 @@ from pyspades.constants import (BLOCK_TOOL, CTF_MODE, ERROR_FULL,
                                 ERROR_TOO_MANY_CONNECTIONS,
                                 ERROR_WRONG_VERSION, FALL_KILL, HEAD,
                                 HEADSHOT_KILL, HIT_TOLERANCE,
-                                MAX_BLOCK_DISTANCE, MAX_POSITION_RATE, MELEE,
-                                MELEE_DISTANCE, MELEE_KILL,
+                                FOG_DISTANCE, MAX_BLOCK_DISTANCE, MAX_POSITION_RATE,
+                                MELEE, MELEE_DISTANCE, MELEE_KILL,
                                 RAPID_WINDOW_ENTRIES, SPADE_TOOL,
                                 TC_CAPTURE_DISTANCE, TC_MODE, WEAPON_KILL,
                                 WEAPON_TOOL)
@@ -385,6 +385,12 @@ class ServerConnection(BaseConnection):
                 return
             hit_amount = self.protocol.melee_damage
         else:
+            # only calculate distance on XY plane -- fog is a cylinder
+            # add rubberband distance to give laggy players leeway
+            dx = position1.x - position2.x
+            dy = position1.y - position2.y
+            if math.sqrt(dx * dx + dy * dy) > FOG_DISTANCE + self.rubberband_distance:
+                return
             hit_amount = self.weapon_object.get_damage(
                 value, position1, position2)
         if is_melee:

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -362,38 +362,39 @@ class ServerConnection(BaseConnection):
 
     @register_packet_handler(loaders.HitPacket)
     def on_hit_recieved(self, contained):
-        if not self.hp:
-            return
         world_object = self.world_object
         value = contained.value
         is_melee = value == MELEE
-        if not is_melee and self.weapon_object.is_empty():
-            return
-        try:
-            player = self.protocol.players[contained.player_id]
-        except KeyError:
-            return
-        valid_hit = world_object.validate_hit(player.world_object,
-                                              value, HIT_TOLERANCE,
-                                              self.rubberband_distance)
-        if not valid_hit:
-            return
-        position1 = world_object.position
-        position2 = player.world_object.position
-        if is_melee:
-            if not vector_collision(position1, position2,
-                                    MELEE_DISTANCE):
-                return
-            hit_amount = self.protocol.melee_damage
-        else:
-            hit_amount = self.weapon_object.get_damage(
-                value, position1, position2)
         if is_melee:
             kill_type = MELEE_KILL
         elif contained.value == HEAD:
             kill_type = HEADSHOT_KILL
         else:
             kill_type = WEAPON_KILL
+        try:
+            player = self.protocol.players[contained.player_id]
+        except KeyError:
+            return
+        position1 = world_object.position
+        position2 = player.world_object.position
+        if is_melee:
+            hit_amount = self.protocol.melee_damage
+        else:
+            hit_amount = self.weapon_object.get_damage(
+                value, position1, position2)
+        self.on_unvalidated_hit(hit_amount, player, kill_type, None)
+        if not self.hp:
+            return
+        if not is_melee and self.weapon_object.is_empty():
+            return
+        valid_hit = world_object.validate_hit(player.world_object,
+                                              value, HIT_TOLERANCE,
+                                              self.rubberband_distance)
+        if not valid_hit:
+            return
+        if is_melee and not vector_collision(position1, position2,
+                                             MELEE_DISTANCE):
+            return
         returned = self.on_hit(hit_amount, player, kill_type, None)
         if returned == False:
             return
@@ -1125,6 +1126,7 @@ class ServerConnection(BaseConnection):
                 damage = grenade.get_damage(player.world_object.position)
                 if damage == 0:
                     continue
+                self.on_unvalidated_hit(damage, player, GRENADE_KILL, grenade)
                 returned = self.on_hit(damage, player, GRENADE_KILL, grenade)
                 if returned == False:
                     continue
@@ -1269,6 +1271,9 @@ class ServerConnection(BaseConnection):
         pass
 
     def on_hit(self, hit_amount, hit_player, kill_type, grenade):
+        pass
+
+    def on_unvalidated_hit(self, hit_amount, hit_player, kill_type, grenade):
         pass
 
     def on_kill(self, killer, kill_type, grenade):

--- a/pyspades/world.pyx
+++ b/pyspades/world.pyx
@@ -34,7 +34,7 @@ cdef extern from "world_c.cpp":
     int c_validate_hit "validate_hit" (
         float shooter_x, float shooter_y, float shooter_z,
         float orientation_x, float orientation_y, float orientation_z,
-        float victim_x, float victim_y, float victim_z, float tolerance)
+        float victim_x, float victim_y, float victim_z, float aim_tolerance, float dist_tolerance)
     int c_can_see "can_see" (MapData * map, float x0, float y0, float z0,
         float x1, float y1, float z1)
     int c_cast_ray "cast_ray" (MapData * map, float x0, float y0, float z0,
@@ -190,7 +190,7 @@ cdef class Character(Object):
             return x, y, z
         return None
 
-    def validate_hit(self, Character other, part, float tolerance):
+    def validate_hit(self, Character other, part, float aim_tolerance, float dist_tolerance):
         """check if a given hit is within a given tolerance of hitting another
         player. This is primarily used to prevent players from shooting at
         things they aren't facing at"""
@@ -213,7 +213,7 @@ cdef class Character(Object):
             return False
         if not c_validate_hit(position1.x, position1.y, position1.z,
                               orientation.x, orientation.y, orientation.z,
-                              x, y, z, tolerance):
+                              x, y, z, aim_tolerance, dist_tolerance):
             return False
         return True
 


### PR DESCRIPTION
... and silently reject any hits from well beyond fog range. This prevents cheaters from making literally impossible shots from the whole map away. We've had this running on aloha for ages without issue.

Doing the sqrt() in plain view personally feels less dirty to me than creating a Vertex3 just to use 2/3 of its fields and dispose of it immediately, but if you guys would rather me do that I'll change it, no big deal.
Also, I'm slightly annoyed at pyspades' lack of a Vector2/Vertex2 class.

It's a mystery to me as to why FOG_DISTANCE doesn't normally exist in the first place.