### PR TITLE
Cap grenade velocity relative to player

### DIFF
--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -412,12 +412,17 @@ class ServerConnection(BaseConnection):
         self.grenades -= 1
         if not self.check_speedhack(*contained.position):
             contained.position = self.world_object.position.get()
+        velocity = Vertex3(*contained.velocity) - self.world_object.velocity
+        if velocity.length() > 2.0: # cap at tested maximum
+            velocity.normalize()
+            velocity *= 2.0
+        velocity += self.world_object.velocity
         if self.on_grenade(contained.value) == False:
             return
         grenade = self.protocol.world.create_object(
             world.Grenade, contained.value,
             Vertex3(*contained.position), None,
-            Vertex3(*contained.velocity), self.grenade_exploded)
+            velocity, self.grenade_exploded)
         grenade.team = self.team
         log.debug("{player!r} ({world_object!r}) created {grenade!r}",
                   grenade=grenade, world_object=self.world_object, player=self)

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -414,8 +414,7 @@ class ServerConnection(BaseConnection):
             contained.position = self.world_object.position.get()
         velocity = Vertex3(*contained.velocity) - self.world_object.velocity
         if velocity.length() > 2.0: # cap at tested maximum
-            velocity.normalize()
-            velocity *= 2.0
+            velocity = velocity.normal() * 2.0
         velocity += self.world_object.velocity
         if self.on_grenade(contained.value) == False:
             return


### PR DESCRIPTION
This severely reduces the effectiveness of cheats that throw grenades out at ridiculous velocities. This has been running on aloha for a long time without any issues.

The 2.0 magic length comes from some pretty rigorous testing, I couldn't get it any higher than 2.0 on an unmodified client in even the worst of conditions (falling at terminal velocity, throwing the grenade straight down, with lag). Perhaps this should be moved into a constant.