### PR TITLE
Filter some malicious characters from names and chat

### DIFF
--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -606,6 +606,7 @@ class ServerConnection(BaseConnection):
                 return
             elif result is not None:
                 value = result
+            value = value.replace('\n', '')
             contained.chat_type = CHAT_ALL if global_message else CHAT_TEAM
             contained.value = value
             contained.player_id = self.player_id

--- a/pyspades/server.py
+++ b/pyspades/server.py
@@ -342,7 +342,11 @@ class ServerProtocol(BaseProtocol):
 
         Returns the fixed name.
         '''
+        name = name.replace('\n', '')
+        name = name.replace('#', '')
         name = name.replace('%', '')
+        if not name:
+            name = 'Deuce'
         new_name = name
         names = [p.name.lower() for p in self.players.values()]
         i = 0


### PR DESCRIPTION
For a short while '#' was used a lot by some people on our servers to avoid getting votekicked, as it interfered with player IDs.