### PR TITLE
Bump jinja2 dependency to >=3.0.0,<4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # core
 Cython>=0.27,<1
-Jinja2>=2,<4
+Jinja2>=3.0.0,<4
 pyenet
 toml
 Pillow>=5.1.0,<10


### PR DESCRIPTION
Avoids an upstream issue where Jinja2 did not constrain MarkupSafe versions, then MarkupSafe introduced a breaking change.

There's a lot of discussion on Jinja2 about backporting a fix for v2.11.3, but it looks like it's best to just update the (now unsupported) Jinja2 v2.11.3 to 3.x.x.  
https://github.com/pallets/markupsafe/issues/286  
https://github.com/pallets/jinja/issues/1585

I'm admittedly not very familiar with the codebase yet. I spot checked StatusServer and it seems to work fine after the bump. I've now had an instance running for 3 days or so and the status page still works & renders correctly. The [Jinja2 changelog](https://jinja.palletsprojects.com/en/3.1.x/changes/) doesn't seem to show any potential issues either.

Fixes #716