### PR TITLE
Patch `send_lines` exploit

### DIFF
--- a/piqueserver/console.py
+++ b/piqueserver/console.py
@@ -99,7 +99,7 @@ class ConsoleInput(LineReceiver):
     def send_chat(self, value: str, _):
         print(value)
 
-    def send_lines(self, lines: List[str]):
+    def send_lines(self, lines: List[str], type: str = None):
         print("\n".join(lines))
 
 

--- a/piqueserver/core_commands/info.py
+++ b/piqueserver/core_commands/info.py
@@ -36,7 +36,7 @@ def rules(connection):
     lines = connection.protocol.rules
     if lines is None:
         return
-    connection.send_lines(lines)
+    connection.send_lines(lines, 'rules')
 
 
 @command()
@@ -57,7 +57,7 @@ def commands(connection):
             continue
         desc, _, _ = get_command_help(cmd)
         lines.append("/{} {}".format(cmd.command_name, desc))
-    connection.send_lines(lines)
+    connection.send_lines(lines, 'commands')
 
 
 @command("help")
@@ -75,4 +75,4 @@ def help_command(connection, command_name=None):
         return 'Description: {}\n Usage: {}'.format(desc, usage)
     # Output help if present in config
     if connection.protocol.help:
-        return connection.send_lines(connection.protocol.help)
+        return connection.send_lines(connection.protocol.help, 'help')

--- a/piqueserver/irc.py
+++ b/piqueserver/irc.py
@@ -187,7 +187,7 @@ class IRCBot(irc.IRCClient):
     def send_chat(self, value: str, _):
         self.send(value)
 
-    def send_lines(self, lines: List[str]):
+    def send_lines(self, lines: List[str], type: str = None):
         self.send("\n".join(lines))
 
 class IRCClientFactory(protocol.ClientFactory):

--- a/piqueserver/player.py
+++ b/piqueserver/player.py
@@ -334,6 +334,7 @@ class FeatureConnection(ServerConnection):
                                       self.name)
 
     def send_lines(self, lines: List[str]) -> None:
+        # TODO: address here
         current_time = 0
         for line in lines:
             reactor.callLater(current_time, self.send_chat, line)

--- a/piqueserver/scripts/markers.py
+++ b/piqueserver/scripts/markers.py
@@ -97,7 +97,7 @@ def toggle_markers(connection, player=None):
 @command()
 @player_only
 def markers(connection):
-    connection.send_lines(S_HELP)
+    connection.send_lines(S_HELP, 'markers_help')
 
 
 class BaseMarker():

--- a/piqueserver/scripts/squad.py
+++ b/piqueserver/scripts/squad.py
@@ -80,7 +80,7 @@ def squad(self, squadkey=None):
                 squadkey, allsquads[squadkey]))
         result.append(('To join squads: /squad <squad name>. ' +
                        '/squad none to spawn normally.'))
-        self.send_lines(result)
+        self.send_lines(result, 'squad_list')
         return
 
     if squadkey.lower() == 'none':


### PR DESCRIPTION
# About

> Note: This should be merged alongside #721 to fully patch the two exploits mentioned in #624.

Piqueserver does not prevent users from spamming commands which utilize the `send_lines` function. For commands that send a relatively larger amount of lines in the `send_lines` function, such as `/commands`, this exacerbates the issue.

This pull request does not deal with command spam (which has been left to #624) – this pull request *does* deal with multiple `send_lines` calls of the same underlying reason.

# Explanation of implementation

To address this exploit, I have added a set "`current_send_lines_types`" to `FeatureConnection`, which stores the list of types that a player is currently being sent.

Types are simply 'reasons' that `send_lines` has been called, which serve as identifiers, so that `send_lines` can be called only once at a time for a particular message.

For example, running `/commands` uses the type `commands` for the `send_lines` function.

If `send_lines` is called but the user is already receiving the lines of the given `type`, then an `info`-level message is logged to the console to inform the server that the function call has been silently discarded.

# To-do

- [x] Initial commit to fix exploit
- [x] Maintainer's satisfaction with the direction of this PR
- [x] Document the `type` parameter on `send_lines`
- [x] Mark pull request as 'ready to merge'