### PR TITLE
Speed up client detection

### DIFF
--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -657,7 +657,7 @@ class ServerConnection(BaseConnection):
     @register_packet_handler(loaders.HandShakeReturn)
     def on_handshake_recieved(self, contained: loaders.HandShakeReturn) -> None:
         version_request = loaders.VersionRequest()
-        self.protocol.broadcast_contained(version_request)
+        self.send_contained(version_request)
 
     @register_packet_handler(loaders.VersionResponse)
     def on_version_info_recieved(self, contained: loaders.VersionResponse) -> None:


### PR DESCRIPTION
**Description**
- Client detection was being slow, and when using detectclient script the detection by detectclient was being really faster than piqueserver one. When removing the packets sent by piqueserver core, detectclient is slow like piqueserver

**How to reproduce?**
- Join in the server with the benchmark script (at the end of this)

**Why this need to be merged?**
- Because some scripts need to know the user's client in the fastest way for doing some gamemode/script change.

Detect client speed when using piqueserver's _connection_ack handshake:
![](https://cdn.discordapp.com/attachments/982983753448185898/985546480980987964/Screenshot_2022-06-12-11-09-41_1024x768.png)

Benchmark before the changes:
![Screenshot_2022-06-12-12-17-50_1024x768](https://user-images.githubusercontent.com/93609026/173240030-ac0eb74d-a182-4ad9-b5b8-53f8f4e95f09.png)

Benchmark after the changes:
![Screenshot_2022-06-12-12-20-45_1024x768](https://user-images.githubusercontent.com/93609026/173240167-fc9f09c4-617e-4bac-b705-5a0ad49b6e2f.png)

Benchmark script:
```py
from time import time
from pyspades.packet import register_packet_handler
from pyspades.contained import VersionResponse

def apply_script(protocol, connection, config):
	class ffsConnection(connection):
		def __init__(self, *args, **kw):
			self.testStart = time()
			return connection.__init__(self, *args, **kw)

		@register_packet_handler(VersionResponse)
		def on_version_info_recieved(self, contained):
			print("[PIQUESERVER] - In: {}".format(time()-self.testStart))
			return connection.on_version_info_recieved(self,contained)

		def on_version_answer(self, info):
			print("[DCLIENT] - In {}".format(time()-self.testStart))
			return connection.on_version_answer(self, info)

	return protocol, ffsConnection
```