### PR TITLE
Wrong bans being deleted

### DIFF
--- a/piqueserver/networkdict.py
+++ b/piqueserver/networkdict.py
@@ -73,7 +73,10 @@ class NetworkDict:
         self.networks.pop(ip)
 
     def pop(self, *arg, **kw):
-        network, value = self.networks.pop(*arg, **kw)
+        if not arg or not kw:
+            network, value = self.networks.popitem()
+        else:
+            network, value = self.networks.pop(*arg, **kw)
         return get_cidr(network), value
 
     def iteritems(self):

--- a/piqueserver/networkdict.py
+++ b/piqueserver/networkdict.py
@@ -70,10 +70,10 @@ class NetworkDict:
 
     def __delitem__(self, key):
         ip = ip_network(str(key), strict=False)
-        self.networks.popitem(ip)
+        self.networks.pop(ip)
 
     def pop(self, *arg, **kw):
-        network, value = self.networks.popitem(*arg, **kw)
+        network, value = self.networks.pop(*arg, **kw)
         return get_cidr(network), value
 
     def iteritems(self):


### PR DESCRIPTION
**Description**
- This PR is related to the issue #619, bans was always deleting the last ban when reaching the time, i still don't know how Rakete's bans got that timestamp... But, this is going to fix an issue related to another bans being removed.

**How to reproduce?**
- Start the server, do a ban ip in a random ip with the time of 1m (1 minute). Now ban other IPs, make a copy of the bans.txt for checking which bans got removed, then just restart the server after 1 minute. When checking the bans.txt and comparing with the copy, you will be able to notice the 1 minute ban still on there (what will cause more bans being vanished), and the last ban you did got removed. So, if you had more bans that got expired, more wrong bans was going to be removed.

**Some screenshots:**
* Console saying that removed 1 ban:
![Screenshot_2022-06-16-08-51-40_1024x768](https://user-images.githubusercontent.com/93609026/174063835-d3ad0c04-a037-42ca-bd34-175bdee8a13a.png)

* New bans.txt (69.69.69.69 got banned for 1 minute):
![Screenshot_2022-06-16-08-52-32_1024x768](https://user-images.githubusercontent.com/93609026/174063973-8301dc8e-154d-4802-9b60-68c28076f68b.png)

* Old bans.txt:
![Screenshot_2022-06-16-08-53-59_1024x768](https://user-images.githubusercontent.com/93609026/174064213-65aa4be1-a8ce-484f-b2ef-98d6d0353e3c.png)

* Permanent ban being removed:
![Screenshot_2022-06-16-08-54-36_1024x768](https://user-images.githubusercontent.com/93609026/174064339-1a756655-0166-4c0f-b499-a79986328eae.png)

