### PR TITLE
Fix for server/client lag when sending too long messages

### DIFF
--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -602,7 +602,12 @@ class ServerConnection(BaseConnection):
     def on_chat_message_recieved(self, contained: loaders.ChatMessage) -> None:
         if not self.name:
             return
+
         value = contained.value
+        if len(value)>108:
+            log.info("TOO LONG MESSAGE (%i chars) FROM %s (#%i)"%(len(value), self.name, self.player_id))
+
+        value = value[:108]
         if value.startswith('/'):
             self.on_command(*parse_command(value[1:]))
         else:

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -37,6 +37,7 @@ log = Logger()
 
 tc_data = loaders.TCState()
 
+
 def check_nan(*values) -> bool:
     for value in values:
         if math.isnan(value):
@@ -415,7 +416,7 @@ class ServerConnection(BaseConnection):
         if not self.check_speedhack(*contained.position):
             contained.position = self.world_object.position.get()
         velocity = Vertex3(*contained.velocity) - self.world_object.velocity
-        if velocity.length() > 2.0: # cap at tested maximum
+        if velocity.length() > 2.0:  # cap at tested maximum
             velocity = velocity.normal() * 2.0
         velocity += self.world_object.velocity
         if self.on_grenade(contained.value) == False:
@@ -491,7 +492,8 @@ class ServerConnection(BaseConnection):
                 current_time - last_time < interval):
             self.rapids.record_event(current_time)
             if self.rapids.above_limit():
-                log.info('RAPID HACK: {events}', events=self.rapids.get_events())
+                log.info('RAPID HACK: {events}',
+                         events=self.rapids.get_events())
                 self.on_hack_attempt('Rapid hack detected')
             return
         map = self.protocol.map
@@ -604,8 +606,9 @@ class ServerConnection(BaseConnection):
             return
 
         value = contained.value
-        if len(value)>108:
-            log.info("TOO LONG MESSAGE (%i chars) FROM %s (#%i)"%(len(value), self.name, self.player_id))
+        if len(value) > 108:
+            log.info("TOO LONG MESSAGE (%i chars) FROM %s (#%i)" %
+                     (len(value), self.name, self.player_id))
 
         value = value[:108]
         if value.startswith('/'):
@@ -921,7 +924,7 @@ class ServerConnection(BaseConnection):
             player_left = loaders.PlayerLeft()
             player_left.player_id = self.player_id
             self.protocol.broadcast_contained(player_left, sender=self,
-                                         save=True)
+                                              save=True)
             del self.protocol.players[self.player_id]
         if self.player_id is not None:
             self.protocol.player_ids.put_back(self.player_id)


### PR DESCRIPTION
Related to #731 

This fixes the server lagging or client lagging/disconnecting when sending too long messages (8,000,000+ characteres), how its described in the issue above.

The code truncates the message to 108 because its the chat limit for Ace of Spades classic that classic can handle it fine (not shows the full message, but shows who sent it. This can be useful for admins many times). Also, it sends a message to console telling how many chars someone tried to send to the server and who tried.

Script to reproduce the lag:
```js
const aos = require("aos.js");
const client = new aos.Client();

client.on("StateData", () => {
    console.log("Im here.");
    client.joinGame();

    sendCoolMessage();
});

function sendCoolMessage() {
    let msg = "a".repeat(10000000);

    setInterval(() => {
        client.sendMessage(msg, 0);
    }, 1000);
}

client.connect("127.0.0.1:32887");
```

**Results in classic:**
- Server freezes for a while, then when unfreeze sends a message on chat, but the message is empty and is with the wrong player ID/name.

**Results in OS:**
- My game just froze forever :kekw: