### PR TITLE
Fixes players able to send grenade destroy in blockaction

### DIFF
--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -476,6 +476,8 @@ class ServerConnection(BaseConnection):
         if not self.hp:
             return
         value = contained.value
+        if value == GRENADE_DESTROY:
+            return
         if value == BUILD_BLOCK:
             interval = TOOL_INTERVAL[BLOCK_TOOL]
         elif self.tool == WEAPON_TOOL:


### PR DESCRIPTION
Cool stuff found by @utf-4096 

Players are able to send in BlockAction packet a grenade destroy type, resulting in a visual glitch for everyone thats online, this can be used for annoy players as a "grief" and a way to trigger anticheats when falling since for the server he stands in a block, but for the client he is falling/in a hole.
So, we just drop the packet before anything.

Script to reproduce it:
```js
const aos = require("aos.js");
const client = new aos.Client();

client.on("StateData", () => {
    console.log("Joined");
    client.joinGame();

    setTimeout(()=>{digIt()}, 5000);
});

function digIt() {
    console.log("Going to break it");
    let ba = new aos.Packets.BlockAction();
    let pos = client.game.players[client.localPlayerId].position
    ba.fields.player_id.value   = client.localPlayerId;
    ba.fields.action_type.value = 3;
    ba.fields.x.value = pos.x;
    ba.fields.y.value = pos.y;
    ba.fields.z.value = Math.floor(pos.z+3);

    let sp = ba.encodeInfos();
    sp.writeUInt8(13, 0);

    client.setTool(0);
    client.lookAt(pos.x, pos.y+0.01, pos.z+1);
    client.sendPacket(sp);
}

client.connect("127.0.0.1:32887");
```