### PR TITLE
Fix for test ban subscribe crashing in python 3.9

### DIFF
--- a/tests/piqueserver/test_ban_pubsub.py
+++ b/tests/piqueserver/test_ban_pubsub.py
@@ -25,7 +25,7 @@ async def test_ban_manger_update_bans():
         {"ip":"177.142.42.13","name":"Danko","reason":"Cheating"},
     ]
     site = await mock_server(data, 9191)
-    asyncio.get_event_loop().create_task(site.start())
+    await site.start()
 
     banm = bansubscribe.BanManager(Mock())
     banm.urls = [("http://localhost:9191/", ["Danko"])]


### PR DESCRIPTION
Looks like Python 3.9 ban test is crashing because web server not starts at the correct time, resulting to not be able to fetch bans at time.
When testing multiple times you can see it happening, random times that works, or that just crashes again. I don't know why that not happens in <3.9 versions...