### PR TITLE
Fix for votekick returning "Invalid Player" when trying to votekick players with # in name

### DIFF
--- a/piqueserver/scripts/blockinfo.py
+++ b/piqueserver/scripts/blockinfo.py
@@ -28,7 +28,8 @@ from piqueserver.commands import command, admin, get_player
 from piqueserver.config import config
 
 blockinfo_config = config.section("blockinfo")
-GRIEFCHECK_ON_VOTEKICK = blockinfo_config.option("griefcheck_on_votekick", True)
+GRIEFCHECK_ON_VOTEKICK = blockinfo_config.option(
+    "griefcheck_on_votekick", True)
 IRC_ONLY = blockinfo_config.option("irc_only", False)
 
 
@@ -159,7 +160,7 @@ def apply_script(protocol, connection, config):
             result = protocol.on_votekick_start(
                 self, instigator, victim, reason)
             if result is None and GRIEFCHECK_ON_VOTEKICK.get():
-                message = grief_check(instigator, victim.name)
+                message = grief_check(instigator, "#%i" % victim.player_id)
                 if IRC_ONLY.get():
                     self.irc_say('* ' + message)
                 else:

--- a/piqueserver/scripts/ratio.py
+++ b/piqueserver/scripts/ratio.py
@@ -81,7 +81,7 @@ def apply_script(protocol, connection, config):
             result = protocol.on_votekick_start(
                 self, instigator, victim, reason)
             if result is None and RATIO_ON_VOTEKICK:
-                message = ratio(instigator, victim.name)
+                message = ratio(instigator, "#%i" % victim.player_id)
                 if IRC_ONLY:
                     self.irc_say('* ' + message)
                 else:


### PR DESCRIPTION
This will fix a bug related to votekick script, where if a player joins with # in start of the nickname, was unable to get votekicked when server had ratio or blockinfo enabled (most servers does that). That happened because these scripts was giving the player's name instead of the player's id, so when get_player tries to find the player "###" it can't find since # is not an ID (this probably can be fixed in a future PR).

**Steps to reproduce:**
1. Enable the scripts: votekick, ratio and blockinfo (in this order).
2. Join in the server with some users, and one using # as his nickname
3. Try to votekick the # guy.

This probably is related to #709 , so that can be closed or merged.