### PR TITLE
Add config options and player isolation in blue team

### DIFF
--- a/piqueserver/game_modes/freeforall.py
+++ b/piqueserver/game_modes/freeforall.py
@@ -18,7 +18,7 @@ Options
     isolate_player = true
 
     # If USE_SCORE_HACK is True, then when you kill someone
-    # he will get changed to the other team, so you can
+    # that player will appear to be on the other team, so you can
     # get score when playing on voxlap
     use_score_hack = false
 ..

--- a/piqueserver/game_modes/freeforall.py
+++ b/piqueserver/game_modes/freeforall.py
@@ -14,7 +14,7 @@ Options
     water_spawns = false
 
     # If ISOLATE_PLAYER is True, then player will be alone in
-    # the blue team, vs all greens auto disabling use_score_hack
+    # the blue team, vs all greens. This auto disable use_score_hack
     isolate_player = true
 
     # If USE_SCORE_HACK is True, then when you kill someone
@@ -80,10 +80,10 @@ def apply_script(protocol, connection, config):
                 if contained.id == CreatePlayer.id:
                     if contained.team != -1:
                         player = self.players[contained.player_id]
-                        contained.team = self.blue_team.id
+                        contained.team = self.team_1.id
 
                         player.send_contained(contained)
-                        contained.team = self.green_team.id
+                        contained.team = self.team_2.id
                         sender = player
 
             return protocol.broadcast_contained(self, contained, unsequenced,
@@ -96,7 +96,7 @@ def apply_script(protocol, connection, config):
             if team.spectator or not ISOLATE_PLAYER.get():
                 return team
 
-            return self.protocol.green_team
+            return self.protocol.team_2
 
         def on_spawn_location(self, pos):
             if not self.score_hack and self.protocol.free_for_all:
@@ -125,7 +125,7 @@ def apply_script(protocol, connection, config):
 
         def on_kill(self, by, _type, grenade):
             # Switch teams to add score hack
-            if USE_SCORE_HACK.get():
+            if USE_SCORE_HACK.get() and not ISOLATE_PLAYER.get():
                 if by is not None and by.team is self.team and self is not by:
                     self.score_hack = True
                     pos = self.world_object.position

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -956,7 +956,7 @@ class ServerConnection(BaseConnection):
         if by is not None and self.team is by.team:
             friendly_fire = self.protocol.friendly_fire
             friendly_fire_on_grief = self.protocol.friendly_fire_on_grief
-            if friendly_fire_on_grief:
+            if friendly_fire_on_grief and not friendly_fire:
                 if (kill_type == MELEE_KILL and
                         not self.protocol.spade_teamkills_on_grief):
                     return
@@ -964,7 +964,7 @@ class ServerConnection(BaseConnection):
                 if (self.last_block_destroy is None
                         or reactor.seconds() - self.last_block_destroy >= hit_time):
                     return
-            elif not friendly_fire:
+            if not friendly_fire:
                 return
         self.set_hp(self.hp - value, by, kill_type=kill_type)
 


### PR DESCRIPTION
This will add config options, so players can change the gamemode options inside their config. And add the option to isolate players in a different team, what actually happens is: server will set all players to green team, but when player tries to spawn server sends to the player a packet saying "hey you is on blue team", and for other players server sends "hey that dude is on green".

_(Also fixes an issue with team damage, that was not working right when having team damage on grief enabled)_

Fixes #211 