### PR TITLE
Use cibuildwheel instead of manual wheel building on github

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,30 +5,25 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools cython wheel
+      - uses: actions/checkout@v3
 
       - name: Build
-        run: |
-          python setup.py sdist
-          python setup.py bdist_wheel
+        uses: pypa/cibuildwheel@v2.13.1
+        env:
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
+          CIBW_BUILD_FRONTEND: "build"
+          CIBW_SKIP: "pp*"
+        with:
+          output-dir: wheelhouse
 
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
           name: python-wheel
-          path: ./dist/*.whl
+          path: ./wheelhouse/*.whl


### PR DESCRIPTION
Right now piqueserver is building wheels "manually" only for linux, so moving to cibuildwheel lets us build for manylinux and different architectures. Also added support for windows builds.