### PR TITLE
Fix action building failing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,12 +26,12 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           export CYTHON_TRACE=1
-          python setup.py develop
+          pip install -e .
       - name: Build on windows
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
           set CYTHON_TRACE=1
-          python setup.py develop
+          pip install -e .
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names


### PR DESCRIPTION
Actions are failing because setuptools doesn't support running setup.py directly, so now it will run using pip.

https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html