### PR TITLE
Send extensions in HELLOLAN

### DIFF
--- a/piqueserver/server.py
+++ b/piqueserver/server.py
@@ -771,7 +771,8 @@ class FeatureProtocol(ServerProtocol):
                     "players_max": self.max_players,
                     "map": map_name,
                     "game_mode": self.get_mode_name(),
-                    "game_version": "0.75"
+                    "game_version": "0.75",
+                    "extensions": self.available_proto_extensions
                 }
                 payload = json.dumps(entry).encode()
                 self.host.socket.send(address, payload)


### PR DESCRIPTION
Send extensions in HELLOLAN, so clients can display what which server supports as extension.

Test script:
```py
from socket import socket, AF_INET, SOCK_DGRAM
import json

with socket(AF_INET, SOCK_DGRAM) as client:
	client.sendto(b'HELLOLAN', ("127.0.0.1", 32887))
	data, server = client.recvfrom(1024)
	print(json.loads(data))
```