### PR TITLE
perf(mapgenerator): lower the compression level to 5

### DIFF
--- a/pyspades/mapgenerator.py
+++ b/pyspades/mapgenerator.py
@@ -4,7 +4,7 @@ to the client on connect
 """
 import zlib
 
-COMPRESSION_LEVEL = 9
+COMPRESSION_LEVEL = 5
 
 
 class ProgressiveMapGenerator:


### PR DESCRIPTION
This PR is a proposal to lower the compression level from 9 to 5.

Here are some tests I made from compressing Aloha's map repository (806 maps):

| Level | Average time | Average size |
| ----- | ------------ | ------------ |
| 9     | 325ms        | 510KiB       |
| 5     | 48ms         | 539KiB       |

Level 9 is only ~1.06x smaller than level 5 on average, but takes **6.7x as long** to compress.

Additionally, [SpadesX already uses level 5](https://github.com/SpadesX/SpadesX/blob/master/Source/Util/Compress.c#L66).

Much higher compression times for a very small decrease in size doesn't sound like it's worth it, so I think it's better to change it :)
