### PR TITLE
fix(player): drop grenades with invalid velocity and keep calculations in sync

### DIFF
--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -424,6 +424,7 @@ class ServerConnection(BaseConnection):
         if length > 2.0:  # cap at tested maximum
             velocity = velocity.normal() * 2.0
         velocity += self.world_object.velocity
+        contained.velocity = (velocity.x, velocity.y, velocity.z)
         if self.on_grenade(contained.value) == False:
             return
         grenade = self.protocol.world.create_object(

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -418,7 +418,10 @@ class ServerConnection(BaseConnection):
         if contained.value > 3.0:
             contained.value = 3.0
         velocity = Vertex3(*contained.velocity) - self.world_object.velocity
-        if velocity.length() > 2.0:  # cap at tested maximum
+        length = velocity.length()
+        if check_nan(length):
+            return
+        if length > 2.0:  # cap at tested maximum
             velocity = velocity.normal() * 2.0
         velocity += self.world_object.velocity
         if self.on_grenade(contained.value) == False:


### PR DESCRIPTION
It's possible to cause an OpenSpades crash whenever someone sends a grenade with a velocity that results in a `length()` of `inf`, which the normal() failsafe doesn't account for.

When sending a grenade with velocity `x=0.01, y=0.01, z=340282346638528859811704183484516925440.00`, we will hit this code:
```py
        if velocity.length() > 2.0:  # cap at tested maximum
            velocity = velocity.normal() * 2.0
```

Calling length() with the values we have, we get `sqrt(0.01 * 0.01 + 0.01 * 0.01 + 340282346638528859811704183484516925440.00 * 340282346638528859811704183484516925440.00)`. The huge Z axis squared gives us infinity, which when squared with the rest, still gives infinity.

Then, in `normal()`, we divide everything by `length()`:
```py
    def normal(self):
        cdef float k = self.length()
        cdef Vector * a = self.value
        return k and create_vertex3(a.x / k, a.y / k, a.z / k) or Vertex3()
```

Which gives a velocity of `x=0.0, y=0.0, z=0.0`. This would be fine, but the server doesn't actually set this new velocity in the `contained` packet.

This PR proposes to drop grenade packets that have a length that fail the `check_nan()` check, *and* also sets the newly calculated velocity in the packet correctly.

