### PR TITLE
ci: bump minimum python version to 3.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Build
         uses: pypa/cibuildwheel@v2.13.1
         env:
-          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8"
           CIBW_BUILD_FRONTEND: "build"
           CIBW_SKIP: "pp*"
         with:


### PR DESCRIPTION
This bumps the minimum python version for CI tests/wheels from 3.7 to 3.8, since 3.7 was announced to be EOL last year: https://www.python.org/downloads/release/python-3717/.
