### PR TITLE
[freebie] [free to merge] [ezmerge] [instantmerge] Add map_extensions.py authors

### DIFF
--- a/piqueserver/scripts/map_extensions.py
+++ b/piqueserver/scripts/map_extensions.py
@@ -1,7 +1,7 @@
 """
 Provides extensions to the map metadata (e.g. water damage).
 
-.. codeauthor:: ?
+.. codeauthor:: triplefox, mat^2
 """
 
 


### PR DESCRIPTION
Hey, it's not a big deal but I saw that the authors were missing. First of all, because I remember it was matthias and triplefox, and second of all because I found the git history proving it: https://github.com/infogulch/pyspades/commit/79373a1e4f81d0633d3536a9c50b607b8f6cb2fc#diff-f9e6f4c59c6b8999016164d37f8f270b8944256fc76bf53c9603e74d5a2239e7 https://github.com/infogulch/pyspades/commit/6cfeb33aa40c880060fe9961ff91a37ba2619af1

Triplefox did the initial script (water damage) and mat added boundary damage and disabled_commands