### PR TITLE
fix: replace improper uses of the Twisted logger

### DIFF
--- a/piqueserver/commands.py
+++ b/piqueserver/commands.py
@@ -403,11 +403,16 @@ def handle_command(connection, command, parameters):
 
     if result == False:
         parameters = ['***'] * len(parameters)
-    log_message = '<{}> /{} {}'.format(connection.name, command,
-                                       ' '.join(parameters))
+
+    log_message = '<{name}> /{command} {parameters}'
     if result:
-        log_message += ' -> %s' % result
-    log.info(escape_control_codes(log_message))
+        log_message += ' -> {result}'
+
+    log.info(log_message,
+             name=escape_control_codes(connection.name),
+             command=escape_control_codes(command),
+             parameters=escape_control_codes(' '.join(parameters)),
+             result=escape_control_codes(result))
 
     return result
 

--- a/piqueserver/core_commands/server.py
+++ b/piqueserver/core_commands/server.py
@@ -21,7 +21,7 @@ def server_name(connection, *arg):
     protocol = connection.protocol
     protocol.set_server_name(name)
     message = "%s changed servername to '%s'" % (connection.name, name)
-    log.info(message)
+    log.info("{message}", message=message)
     connection.protocol.irc_say("* " + message)
     if connection in connection.protocol.players.values():
         return message

--- a/piqueserver/extensions.py
+++ b/piqueserver/extensions.py
@@ -26,7 +26,7 @@ def check_scripts(script_names):
         else:
             seen.add(script)
     if dups:
-        log.warn("Scripts included multiple times: {}".format(dups))
+        log.warn("Scripts included multiple times: {dups}", dups=dups)
         return False
     return True
 
@@ -69,8 +69,12 @@ def load_scripts(script_names, script_dir, script_type):
         spec = spec_scripts or spec_global
         if not spec:
             log.error(
-                "{} '{}' not found in either {} directory or global scope".format(
-                    script_type, script, script_dir))
+                ("{script_type} '{script}' not found in either {script_dir} "
+                 "directory or global scope"),
+                script_type=script_type,
+                script=script,
+                script_dir=script_dir
+            )
             continue
         # namespace module name to avoid shadowing global modules
         # TODO: figure out if there are any right or better ways.
@@ -83,8 +87,12 @@ def load_scripts(script_names, script_dir, script_type):
             script_objects.append(module)
             continue
         except Exception as e: # needs to be broad since we exec the module
-            log.failure("Error while loading {} {}: {!r}".format(
-                script_type, script, e))
+            log.failure(
+                "Error while loading {script_type} {script}: {exception!r}",
+                script_type=script_type,
+                script=script,
+                exception=e
+            )
 
     return script_objects
 

--- a/piqueserver/irc.py
+++ b/piqueserver/irc.py
@@ -94,7 +94,7 @@ class IRCBot(irc.IRCClient):
         if irc_channel.lower() == self.factory.channel:
             self.ops = set()
             self.voices = set()
-        log.info("Joined channel %s" % irc_channel)
+        log.info("Joined channel {irc_channel}", irc_channel=irc_channel)
 
     def irc_NICK(self, prefix, params):
         user = prefix.split('!', 1)[0]
@@ -150,7 +150,7 @@ class IRCBot(irc.IRCClient):
                 len(self.protocol.server_prefix) - 1
             msg = msg[len(self.factory.chatprefix):].strip()
             message = ("[irc] <{}> {}".format(prefix + alias, msg))[:max_len]
-            log.info(escape_control_codes(message))
+            log.info('{message}', message=escape_control_codes(message))
             self.factory.server.broadcast_chat(message)
         elif msg.startswith(self.factory.commandprefix) and user in self.ops:
             self.unaliased_name = user
@@ -222,13 +222,21 @@ class IRCClientFactory(protocol.ClientFactory):
         log.info("Connecting to IRC server...")
 
     def clientConnectionLost(self, connector, reason):
-        log.info("Lost connection to IRC server ({}), reconnecting in {} seconds".format(
-            reason, self.lost_reconnect_delay))
+        log.info(
+            ("Lost connection to IRC server ({reason}), reconnecting in"
+             " {time} seconds"),
+            reason=reason,
+            lost_reconnect_delay=self.lost_reconnect_delay
+        )
         reactor.callLater(self.lost_reconnect_delay, connector.connect)
 
     def clientConnectionFailed(self, connector, reason):
-        log.info("Could not connect to IRC server ({}), retrying in {} seconds".format(
-            reason, self.failed_reconnect_delay))
+        log.info(
+            ("Could not connect to IRC server ({reason}), retrying in"
+             " {time} seconds"),
+            reason=reason,
+            time=self.failed_reconnect_delay
+        )
         reactor.callLater(self.failed_reconnect_delay, connector.connect)
 
     def buildProtocol(self, address):

--- a/piqueserver/map.py
+++ b/piqueserver/map.py
@@ -75,7 +75,7 @@ class Map:
             random.seed(seed)
             self.data = self.gen_script(rot_info.name, seed)
         else:
-            log.info("Loading map '%s'..." % self.name)
+            log.info("Loading map '{mapname}'...", mapname=self.name)
             self.load_vxl(rot_info)
 
         log.info('Map loaded successfully. (took {duration:.2f}s)',
@@ -90,10 +90,11 @@ class Map:
             info = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(info)
         except FileNotFoundError:
-            log.error("Map info file not found {}".format(path))
+            log.error("Map info file not found {path}", path=path)
             info = None
         except Exception as e:
-            log.error("Error while loading map info: {!r}".format(e))
+            log.error("Error while loading map info: {exception!r}",
+                      exception=e)
             info = None
 
         self.info = info

--- a/piqueserver/player.py
+++ b/piqueserver/player.py
@@ -63,8 +63,9 @@ class FeatureConnection(ServerConnection):
                 protocol.remove_ban(client_ip)
                 protocol.save_bans()
             else:
-                log.info('banned user {} ({}) attempted to join'
-                         .format(name, client_ip))
+                log.info('banned user {name} ({client_ip}) attempted to join',
+                         name=name,
+                         client_ip=client_ip)
                 self.disconnect(ERROR_BANNED)
                 return
 
@@ -73,8 +74,12 @@ class FeatureConnection(ServerConnection):
         if manager is not None:
             reason = manager.get_ban(client_ip)
             if reason is not None:
-                log.info(('federated banned user (%s) attempted to join, '
-                          'banned for %r') % (client_ip, reason))
+                log.info(
+                    ('federated banned user ({client_ip}) attempted to join, '
+                     'banned for {reason}'),
+                    client_ip=client_ip,
+                    reason=reason
+                )
                 self.disconnect(ERROR_BANNED)
                 return
 
@@ -325,7 +330,7 @@ class FeatureConnection(ServerConnection):
             else:
                 message = '%s was kicked' % self.name
             self.protocol.broadcast_chat(message, irc=True)
-            log.info(message)
+            log.info('{message}', message=message)
         # FIXME: Client should handle disconnect events the same way in both
         # main and initial loading network loops
         self.disconnect(ERROR_KICKED)
@@ -366,8 +371,11 @@ class FeatureConnection(ServerConnection):
         if key != 'unknown':
             if key in self.current_send_lines_types:
                 log.info(
-                    "Skipped sending lines to '{}': already being sent key "
-                    "'{}'".format(self.printable_name, key))
+                    ("Skipped sending lines to '{name}': already being sent "
+                     "key '{key}'"),
+                    name=self.printable_name,
+                    key=key
+                )
                 return
 
             self.current_send_lines_types.append(key)
@@ -383,8 +391,9 @@ class FeatureConnection(ServerConnection):
         self.current_send_lines_types.remove(type)
 
     def on_hack_attempt(self, reason):
-        log.warn('Hack attempt detected from {}: {}'
-                 .format(self.printable_name, reason))
+        log.warn('Hack attempt detected from {name}: {reason}',
+                 name=self.printable_name,
+                 reason=reason)
         self.kick(reason)
 
     def on_user_login(self, user_type, verbose=True):
@@ -412,5 +421,5 @@ class FeatureConnection(ServerConnection):
 
     def timed_out(self):
         if self.name is not None:
-            log.info('%s timed out' % self.printable_name)
+            log.info('{name} timed out', name=self.printable_name)
         ServerConnection.timed_out(self)

--- a/piqueserver/scripts/savemap.py
+++ b/piqueserver/scripts/savemap.py
@@ -70,7 +70,8 @@ def apply_script(protocol, connection, config):
                     self.save_map()
             if savemap_config.option('load_saved_map', False).get():
                 if os.path.isfile(get_path(rot_info.name)):
-                    log.info("Saved version of '%s' found" % rot_info.name)
+                    log.info("Saved version of '{name}' found",
+                             name=rot_info.name)
                     rot_info.name += '.saved'
             await protocol.set_map_name(self, rot_info)
 

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -151,8 +151,11 @@ class ServerConnection(BaseConnection):
             # Existingplayer may only be sent if in the limbo or spectator
             # modes. Without this check, they could respawn themselves
             # instantly on any team they wanted.
-            log.debug("{} tried sending an ExistingPlayer packet while not in"
-                      " limbo or spectator mode".format(self))
+            log.debug(
+                ("{player!r} tried sending an ExistingPlayer packet while not"
+                 " in limbo or spectator mode"),
+                player=self
+            )
             return
 
         old_team = self.team
@@ -634,8 +637,10 @@ class ServerConnection(BaseConnection):
 
         value = contained.value
         if len(value) > 108:
-            log.info("TOO LONG MESSAGE (%i chars) FROM %s (#%i)" %
-                     (len(value), self.name, self.player_id))
+            log.info("TOO LONG MESSAGE ({chars} chars) FROM {name} (#{id})",
+                     chars=len(value),
+                     name=self.name,
+                     id=self.player_id)
 
         value = value[:108]
         if value.startswith('/'):


### PR DESCRIPTION
This replaces all occurences of `log.<method>(format, ...)` where format is either a pre-formatted (with `<str>.format()` or `%`) or a user-controlled string with the pure, unformatted string.

This PR is marked **priority:high** because this allows for a potential DDoS / memory leak in places where a user could specify a Python format string, causing server lag or crash.

I highly recommend script devs also check their scripts for a similar mistake.
