### PR TITLE
fix(commands): dont escape `NoneType`s, and cast other types to string

### DIFF
--- a/piqueserver/commands.py
+++ b/piqueserver/commands.py
@@ -412,7 +412,7 @@ def handle_command(connection, command, parameters):
              name=escape_control_codes(connection.name),
              command=escape_control_codes(command),
              parameters=escape_control_codes(' '.join(parameters)),
-             result=escape_control_codes(result))
+             result=escape_control_codes(str(result)) if result is not None else None)
 
     return result
 


### PR DESCRIPTION
Regression caused by #783, which forgot to account for commands that return None.
Fixes #784
