### PR TITLE
refactor(commands): replace `getfullargspec()` with `signature()`

### DIFF
--- a/piqueserver/core_commands/social.py
+++ b/piqueserver/core_commands/social.py
@@ -34,7 +34,7 @@ def pm(connection, value, *arg):
     """
     player = get_player(connection.protocol, value)
     message = join_arguments(arg)
-    if len(message) == 0:
+    if not message:
         return "Please specify your message"
     player.send_chat('PM from %s: %s' % (connection.name, message))
     return 'PM sent to %s' % player.name


### PR DESCRIPTION
Unlike what was specified in a58ded02a6dc23fea96842ad87e6e66bb3c4b8b6, `getfullargspec()` is *no longer* deprecated, however, it appears to only be kept for Python 2.x compatibility reasons, and the `signature()` api is still recommended. This PR refactors the old code to use the newer `signature()` API.

Also includes a small fix for the `/pm` command.

Closes #486
