### PR TITLE
fix(commands): calculate the right number of params for decorators

### DIFF
--- a/piqueserver/commands.py
+++ b/piqueserver/commands.py
@@ -427,7 +427,7 @@ def _handle_command(connection, command, parameters):
     if not has_permission(command_func, connection):
         return "You can't use this command"
 
-    argspec = inspect.signature(command_func, follow_wrapped=False)
+    argspec = inspect.signature(command_func, follow_wrapped=True)
 
     # all args
     positional_args = [
@@ -448,7 +448,7 @@ def _handle_command(connection, command, parameters):
         if param.kind == param.VAR_POSITIONAL
     ), None)
 
-    max_params = len(positional_args) - min_params - 1
+    max_params = max(0, len(positional_args) - 1)
     len_params = len(parameters)
 
     if len_params < min_params or \


### PR DESCRIPTION
PR #789 was meant to match the old behavior as closely as possible, but that behavior was slightly incorrect.

This changes the signature() call to follow the declaration through the decorators (also corrected the logic for max_params).

Closes #610.
