### PR TITLE
Truly hide the intel on pickup for onectf/babel

### DIFF
--- a/piqueserver/game_modes/babel.py
+++ b/piqueserver/game_modes/babel.py
@@ -7,12 +7,13 @@ Release thread:
 http://www.buildandshoot.com/viewtopic.php?t=2586
 """
 
+import math
 from pyspades.constants import CTF_MODE
 from pyspades.collision import vector_collision
 
 FLAG_SPAWN_POS = (256, 256)
 
-HIDE_POS = (0, 0, 63)
+HIDE_POS = (math.inf, math.inf, 128)
 
 DISABLED, ONE_CTF, REVERSE_ONE_CTF = range(3)
 

--- a/piqueserver/game_modes/onectf.py
+++ b/piqueserver/game_modes/onectf.py
@@ -2,12 +2,13 @@
 One CTF: CTF with a single intel, placed in the center.
 """
 
+import math
 from pyspades.constants import *
 from pyspades.collision import vector_collision
 
 FLAG_SPAWN_POS = (256, 256)
 
-HIDE_POS = (0, 0, 63)
+HIDE_POS = (math.inf, math.inf, 128)
 
 # 1CTF and R1CTF can be enabled via the map metadata. Enable it by setting
 # 'one_ctf' to 'True' or 'reverse_one_ctf' to 'True' in the extensions dictionary. ex:


### PR DESCRIPTION
Copied over from https://github.com/aloha-pk/piqueserver/pull/46.

Sends the untaken intel off to {INFINITY, INFINITY, 128} instead of the top-left corner of the map when the other is taken, thereby making it impossible to see on the map.

Tested on OpenSpades v0.1.2/v0.1.3/v0.1.5, AoS v0.75, and BetterSpades 332a8eb54621eddf6e83253f9b0919d226902ae7. This method of hiding the intel is additionally used in the libspades EXPERIMENTAL server, and has not shown any issues there (that I know of) either.