### PR TITLE
Fix broken votekick.py

### DIFF
--- a/piqueserver/scripts/votekick.py
+++ b/piqueserver/scripts/votekick.py
@@ -334,7 +334,7 @@ def apply_script(protocol, connection, config):
                     reason = votekick.reason
                     votekick.end(S_RESULT_LEFT.format(
                         victim=self.name, victim_id=self.player_id))
-                    self.ban(reason, Votekick.ban_duration)
+                    self.ban(reason, votekick.ban_duration)
                 elif votekick.instigator is self:
                     # instigator leaves, votekick is called off
                     s = S_RESULT_INSTIGATOR_LEFT.format(


### PR DESCRIPTION
When someone leaves the game during a votekick, `AttributeError` will be thrown, because `ban_duration` is not available as a class variable since [this commit](https://github.com/piqueserver/piqueserver/commit/7aa02f5cb2b523556d7ed3a080902fca65350d16). This has three major consequences:
1. `self.ban` is not called, so votekick can be easily avoided by simply leaving the game.
2. `player_id` is not returned to the `IDPool` ([this code](https://github.com/piqueserver/piqueserver/blob/9cf7fd79a4840d2f75575b2c425d449b929f1d0a/pyspades/player.py#L964) is called by [this line](https://github.com/piqueserver/piqueserver/blob/9cf7fd79a4840d2f75575b2c425d449b929f1d0a/piqueserver/scripts/votekick.py#L348), but the latter is not executed due to the exception). That `player_id` will disappear completely until the server is restarted, so eventually `IDPool` will pop IDs greater than 31. This is a major problem for the voxlap users: voxlap is simply ignoring such players, observing headshots seemingly out of nowhere.
Moreover, as `self.ban` is not called, it is possible to intentionally votekick yourself from the second client many times in a row, gradually sucking out the available IDs. IDs are just 8-bit in the protocol, but not in the piqueserver internals (they are simply `int`s there), so forcing `IDPool` to pop IDs greater than 255 will completely break the game.
Also [this line](https://github.com/piqueserver/piqueserver/blob/9cf7fd79a4840d2f75575b2c425d449b929f1d0a/pyspades/player.py#L1268) speaks for itself.
3. [This line](https://github.com/piqueserver/piqueserver/blob/9cf7fd79a4840d2f75575b2c425d449b929f1d0a/pyspades/protocol.py#L160) is not called resulting in the buggy player that a) does nothing, b) cannot be kicked, c) disappears when map changes.

I think it’s worth to consider a) moving [this code](https://github.com/piqueserver/piqueserver/blob/9cf7fd79a4840d2f75575b2c425d449b929f1d0a/pyspades/player.py#L956-L966) out of `on_disconnect` and b) wrapping `on_disconnect` [here](https://github.com/piqueserver/piqueserver/blob/9cf7fd79a4840d2f75575b2c425d449b929f1d0a/pyspades/protocol.py#L168) into try-except to prevent such issues in the future.