### PR TITLE
fix(server): skip updating entities with an invalid position

### DIFF
--- a/pyspades/server.py
+++ b/pyspades/server.py
@@ -32,7 +32,7 @@ from pyspades.master import get_master_connection
 from pyspades.team import Team
 from pyspades.entities import Territory
 # importing tc_data is a quick hack since this file writes into it
-from pyspades.player import ServerConnection, tc_data
+from pyspades.player import ServerConnection, check_nan, tc_data
 from pyspades import world
 from pyspades.bytes import ByteWriter
 from pyspades import contained as loaders
@@ -399,6 +399,9 @@ class ServerProtocol(BaseProtocol):
     def update_entities(self):
         map_obj = self.map
         for entity in self.entities:
+            if check_nan(entity.x, entity.y, entity.z):
+                continue
+
             moved = False
             if map_obj.get_solid(entity.x, entity.y, entity.z - 1):
                 moved = True


### PR DESCRIPTION
Related to #793

Trying to update entities that have invalid positions results in `OverflowError`s and in some cases hanging the server.

This PR skips updating entities that have a position that is invalid (which is when any axis is either infinity or nan).
