### PR TITLE
fix(commands): revert to old decorator behavior

### DIFF
--- a/piqueserver/commands.py
+++ b/piqueserver/commands.py
@@ -427,7 +427,7 @@ def _handle_command(connection, command, parameters):
     if not has_permission(command_func, connection):
         return "You can't use this command"
 
-    argspec = inspect.signature(command_func, follow_wrapped=True)
+    argspec = inspect.signature(command_func, follow_wrapped=False)
 
     # all args
     positional_args = [


### PR DESCRIPTION
In #791 I modified commands.py to follow decorators so we could get the "real" argument count. Unfortunately I failed to account for the fact that the decorator `@target_player` adds one extra required argument that is then specified by the decorator. Of course inspect.signature() can't know this, so this breaks all commands that use this decorator unless you explicitly specify the player every time (which is annoying).

I'm not aware of any way in Python to get the decorators of a function, so it looks like this behavior has to stay unless we make a breaking change to the commands API to fix it.

For now, I propose to revert to the old ('less' broken) behavior, so things continue working as intended.
