### PR TITLE
feat(master): implement multiple master servers

### DIFF
--- a/pyspades/master.py
+++ b/pyspades/master.py
@@ -19,20 +19,30 @@
 Implementation of the 0,75 master server protocol
 """
 
+from __future__ import annotations
+from dataclasses import dataclass
+import socket
+from typing import TYPE_CHECKING, Any, Callable, List, TypedDict
+
+from twisted.internet import reactor
+from twisted.logger import Logger
 from pyspades.loaders import Loader
 from pyspades.protocol import BaseConnection
 from pyspades.constants import MASTER_VERSION
 
-from twisted.internet.defer import Deferred
-
-PORT = 32886
+if TYPE_CHECKING:
+    from pyspades.server import ServerProtocol
 
 MAX_SERVER_NAME_SIZE = 31
 MAX_MAP_NAME_SIZE = 20
 MAX_GAME_MODE_SIZE = 7
 
-HOST = 'master.buildandshoot.com'
+log = Logger()
 
+@dataclass
+class MasterHostDescriptor:
+    host: str
+    port: int
 
 class AddServer(Loader):
     """The AddServer packet sent to the master server"""
@@ -65,22 +75,35 @@ add_server = AddServer()
 
 
 class MasterConnection(BaseConnection):
-    disconnect_callback = None
-    connected = False
+    server_protocol: ServerProtocol
+    descriptor: MasterHostDescriptor
+    on_master_connect: Callable[[], None] | None
+    on_master_disconnect: Callable[[], None] | None
+
+    def __init__(self, protocol: Any, peer: Any):
+        super().__init__(protocol, peer)
+        self.was_once_connected: bool = False
+        self.connected: bool = False
 
     def on_connect(self):
         self.connected = True
-        self.send_server()
+        self.was_once_connected = True
+        self.update_server()
 
-        if self.defer is not None:
-            self.defer.callback(self)
-            self.defer = None
+        if callback := self.on_master_connect:
+            callback()
 
-    def set_count(self, value):
+    def on_disconnect(self):
+        self.connected = False
+
+        if callback := self.on_master_disconnect:
+            callback()
+
+    def update_player_count(self, value: int):
         add_server.count = value
         self.send_contained(add_server)
 
-    def send_server(self):
+    def update_server(self):
         protocol = self.server_protocol
         add_server.count = None
         add_server.name = protocol.name[:MAX_SERVER_NAME_SIZE].encode()
@@ -90,19 +113,87 @@ class MasterConnection(BaseConnection):
         add_server.max_players = protocol.max_players
         self.send_contained(add_server)
 
-    def on_disconnect(self):
-        if self.defer is not None:
-            self.defer.errback(self)
-            self.defer = None
-        callback = self.disconnect_callback
-        if callback is not None:
-            callback()
-        self.disconnect_callback = None
+class MasterPool:
+    def __init__(
+        self,
+        protocol: ServerProtocol, *,
+        reconnect_interval: int=30,
+    ) -> None:
+        self.descriptors: List[MasterHostDescriptor] = []
+        self.clients: List[MasterConnection] = []
+        self.protocol = protocol
 
+    def add_descriptor(self, host: str, port: int):
+        descriptor = MasterHostDescriptor(host=host, port=port)
+        self.descriptors += [descriptor]
 
-def get_master_connection(protocol):
-    defer = Deferred()
-    connection = protocol.connect(MasterConnection, HOST, PORT, MASTER_VERSION)
-    connection.server_protocol = protocol
-    connection.defer = defer
-    return defer
+    def add_client(self, desc: MasterHostDescriptor):
+        connection = self.protocol.connect(
+            MasterConnection, desc.host, desc.port, MASTER_VERSION)
+
+        connection.server_protocol = self.protocol
+        connection.descriptor = desc
+        connection.on_master_connect = \
+            lambda: self.on_master_connect(connection)
+        connection.on_master_disconnect = \
+            lambda: self.on_master_disconnect(connection)
+
+        self.clients += [connection]
+
+    def remove_client(self, client: MasterConnection):
+        if client.connected:
+            client.on_master_disconnect = None
+            client.disconnect()
+
+        self.clients.remove(client)
+
+    def up(self):
+        for desc in self.descriptors:
+            try:
+                self.add_client(desc)
+            except OSError as error:
+                log.error(
+                    'Could not add master client [{host}:{port}]: {error}',
+                    host=desc.host,
+                    port=desc.port,
+                    error=error,
+                )
+
+    def down(self):
+        for client in self.clients:
+            self.remove_client(client)
+
+    def reset(self):
+        self.down()
+        self.descriptors = []
+
+    def on_master_connect(self, client: MasterConnection):
+        log.info(
+            'Connection to [{host}:{port}] was successful',
+            host=client.descriptor.host,
+            port=client.descriptor.port,
+        )
+
+    def on_master_disconnect(self, client: MasterConnection):
+        if client.was_once_connected:
+            message = 'Disconnected from [{host}:{port}], reconnecting in 60s'
+        else:
+            # connection failure instead of disconnect
+            message = 'Connection to [{host}:{port}] failed, retrying in 60s'
+
+        log.info(
+            message,
+            host=client.descriptor.host,
+            port=client.descriptor.port,
+        )
+
+        self.remove_client(client)
+        reactor.callLater(60, lambda: self.add_client(client.descriptor))
+
+    def update_server(self):
+        for client in self.clients:
+            client.update_server()
+
+    def update_player_count(self, count: int):
+        for client in self.clients:
+            client.update_player_count(count)


### PR DESCRIPTION
This PR adds the possibility of announcing the server to multiple master server lists, instead of the only previously-hardcoded buildandshoot list.

While buildandshoot has been immensely important to the survival of Ace of Spades, it has also been causing trouble to servers owners in various ways recently. Mainly:
- Lack of action for servers spoofing player count, spamming the server list or impersonating other servers
- No support for servers with >32 players
- Frequent downtimes (from my own measurements: at least 6 times since march this year)

We can't completely get rid of buildandshoot *right now* (or maybe ever), but we can start slowly transitioning away from it by also moving clients to an alternate serverlist (which would merge results from bns & other masterlists, so no one's left out).

Changing master servers has historically been a sensitive topic, so please leave any concerns you might have about this in the comments of this PR.
