### PR TITLE
fix(master): send player count on connect when `count > 0`

### DIFF
--- a/pyspades/master.py
+++ b/pyspades/master.py
@@ -168,6 +168,9 @@ class MasterPool:
         self.descriptors = []
 
     def on_master_connect(self, client: MasterConnection):
+        if (count := self.protocol.get_player_count()) > 0:
+            client.update_player_count(count)
+
         log.info(
             'Connection to [{host}:{port}] was successful',
             host=client.descriptor.host,


### PR DESCRIPTION
Not sending the player count on startup is fine because it is always zero, but if there are players on the server and you reconnect to a master server, the player count won't be updated until someone joins/leaves.

Reported by coherent.sheaf.
