### PR TITLE
fix(master): copy list before iterating when calling `down()`

### DIFF
--- a/pyspades/master.py
+++ b/pyspades/master.py
@@ -160,7 +160,7 @@ class MasterPool:
                 )
 
     def down(self):
-        for client in self.clients:
+        for client in list(self.clients):
             self.remove_client(client)
 
     def reset(self):


### PR DESCRIPTION
I noticed while using `/master` on aloha servers that it took the server off all masterlists except one. I hadn't realized that removing items from a list while also iterating over it is a big no-no.

So, I just copy the list before iterating.
