### PR TITLE
chore: bump python version from 3.8-3.11 to 3.10-3.12 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-tags: true
 
       - name: Build
-        uses: pypa/cibuildwheel@v2.18.0
+        uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_BUILD_FRONTEND: "build"
           CIBW_SKIP: "pp*"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Build
         uses: pypa/cibuildwheel@v2.18.0
         env:
-          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8"
           CIBW_BUILD_FRONTEND: "build"
           CIBW_SKIP: "pp*"
         with:

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ All of these are `bridged <https://matrix.org/docs/guides/faq.html#what-is-matri
 Requirements
 ~~~~~~~~~~~~
 
-Piqueserver requires Python 3.8 and above
+Piqueserver requires Python 3.10 and above
 
 We currently provide builds for:
  - Linux x86_64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ classifiers = [
     "Topic :: Games/Entertainment :: First Person Shooters",
 ]
 
-requires-python = ">= 3.8"
+requires-python = ">= 3.10, < 3.13"
 dependencies = [
     "Jinja2 >= 3.0.0, <4",
     "pyenet",


### PR DESCRIPTION
This PR bumps the minimum Python version from 3.8 to 3.10 and adds 3.12 to the list of supported versions (Cython does not support 3.13, which is why I didn't add it).

Python 3.8 is EOL since 2024-10-07 and 3.9 will be EOL in October this year. Major Linux distros already support Python 3.10+ so there's no reason to keep supporting these versions.

I've removed the cibuildwheel `CIBW_PROJECT_REQUIRES_PYTHON` environment variable override as it is no longer necessary because it can detect the Python version from our `pyproject.toml`, which I have also updated to reflect the supported versions.

I also bumped the cibuildwheel action from v2.18.0 to v2.22.0 (latest as of this PR), for good measure.
