### PR TITLE
fix(statusserver): escape all template values by default

### DIFF
--- a/piqueserver/statusserver.py
+++ b/piqueserver/statusserver.py
@@ -21,7 +21,7 @@ import aiohttp
 from aiohttp import web
 from multidict import MultiDict
 
-from jinja2 import Environment, PackageLoader
+from jinja2 import Environment, PackageLoader, select_autoescape
 import json
 import time
 from PIL import Image
@@ -103,7 +103,10 @@ class StatusServer:
         self.last_update = None
         self.last_map_name = None
         self.cached_overview = None
-        env = Environment(loader=PackageLoader('piqueserver.web'))
+        env = Environment(
+            loader=PackageLoader('piqueserver.web'),
+            autoescape=select_autoescape(),
+        )
         self.status_template = env.get_template('status.html')
 
     async def json(self, request):


### PR DESCRIPTION
This PR enables Jinja's autoescape feature, as mentioned in the [Jinja documentation](https://jinja.palletsprojects.com/en/stable/api/#basics). As all values are now escaped by default, future developers will need to explicitly specify the `|safe` filter to embed raw HTML (which we shouldn't need, anyway).

This fixes several XSS vulnerabilities in the server status page.
