### PR TITLE
Improve TOW gamemode

### DIFF
--- a/piqueserver/game_modes/tow.py
+++ b/piqueserver/game_modes/tow.py
@@ -10,6 +10,9 @@ import math
 from pyspades.constants import TC_MODE
 from pyspades.server import Territory
 
+# Whether to move spawn to the front lines as the game goes on or keep it at the first and last capture point
+MOVE_SPAWN = False
+
 # Procedural generation parameters for when capture points are not specified in map.txt files
 CP_COUNT = 6 # Number of capture points. Must be at least 2
 ANGLE = 65
@@ -21,7 +24,6 @@ FIX_ANGLE = math.radians(4)
 HELP = [
     "In Tug of War, you capture your opponents' front CP to advance."
 ]
-
 
 class TugTerritory(Territory):
     disabled = True
@@ -62,7 +64,6 @@ def get_point(x, y, magnitude, angle):
 
 def apply_script(protocol, connection, config):
     class TugConnection(connection):
-
         def get_spawn_location(self):
             if self.team.spawn_cp is None:
                 base = self.team.last_spawn
@@ -93,16 +94,24 @@ def apply_script(protocol, connection, config):
                         # Blue -> Green
                         self.blue_team.cp  = curr
                         self.green_team.cp = prev
-                        self.blue_team.spawn_cp  = self.get_cp(entities, i - 2)
-                        self.green_team.spawn_cp = self.get_cp(entities, i + 1)
+                        if MOVE_SPAWN:
+                            self.blue_team.spawn_cp  = self.get_cp(entities, i - 2)
+                            self.green_team.spawn_cp = self.get_cp(entities, i + 1)
+                        else:
+                            self.blue_team.spawn_cp = self.blue_team.last_spawn
+                            self.green_team.spawn_cp = self.green_team.last_spawn
                         curr.disabled = False
                         prev.disabled = False
                     elif prev.team is not None and prev.team.id == self.blue_team.id and curr.team == None:
                         # Blue -> Neutral
                         self.blue_team.cp  = curr
                         self.green_team.cp = curr
-                        self.blue_team.spawn_cp  = self.get_cp(entities, i - 2)
-                        self.green_team.spawn_cp = self.get_cp(entities, i + 1)
+                        if MOVE_SPAWN:
+                            self.blue_team.spawn_cp  = self.get_cp(entities, i - 2)
+                            self.green_team.spawn_cp = self.get_cp(entities, i + 1)
+                        else:
+                            self.blue_team.spawn_cp = self.blue_team.last_spawn
+                            self.green_team.spawn_cp = self.green_team.last_spawn
                         curr.disabled = False
                     else: # Disable all other capture points.
                         curr.disabled = True

--- a/piqueserver/game_modes/tow.py
+++ b/piqueserver/game_modes/tow.py
@@ -10,8 +10,8 @@ import math
 from pyspades.constants import TC_MODE
 from pyspades.server import Territory
 
-CP_COUNT = 6
-CP_EXTRA_COUNT = CP_COUNT + 2  # PLUS last 'spawn'
+# Procedural generation parameters for when capture points are not specified in map.txt files
+CP_COUNT = 6 # Number of capture points. Must be at least 2
 ANGLE = 65
 START_ANGLE = math.radians(-ANGLE)
 END_ANGLE = math.radians(ANGLE)
@@ -40,25 +40,20 @@ class TugTerritory(Territory):
         self.disabled = True
         self.progress = float(self.team.id)
 
-
 def get_index(value):
     if value < 0:
         raise IndexError()
     return value
 
-
 def random_up_down(value):
     value /= 2
     return random.uniform(-value, value)
 
-
 def limit_angle(value):
     return min(END_ANGLE, max(START_ANGLE, value))
 
-
 def limit_dimension(value):
     return min(511, max(0, value))
-
 
 def get_point(x, y, magnitude, angle):
     return (limit_dimension(x + math.cos(angle) * magnitude),
@@ -83,110 +78,128 @@ def apply_script(protocol, connection, config):
     class TugProtocol(protocol):
         game_mode = TC_MODE
 
+        def get_cp(self, entities, index):
+            if index < 0:
+                return self.blue_team.last_spawn
+            elif index > len(entities) - 1:
+                return self.green_team.last_spawn
+            return entities[index]
+        
+        def update_cps(self, entities):
+            prev = None
+            for i, curr in enumerate(entities):
+                if prev is not None:
+                    if prev.team is not None and prev.team.id == self.blue_team.id and curr.team is not None and curr.team.id == self.green_team.id:
+                        # Blue -> Green
+                        self.blue_team.cp  = curr
+                        self.green_team.cp = prev
+                        self.blue_team.spawn_cp  = self.get_cp(entities, i - 2)
+                        self.green_team.spawn_cp = self.get_cp(entities, i + 1)
+                        curr.disabled = False
+                        prev.disabled = False
+                    elif prev.team is not None and prev.team.id == self.blue_team.id and curr.team == None:
+                        # Blue -> Neutral
+                        self.blue_team.cp  = curr
+                        self.green_team.cp = curr
+                        self.blue_team.spawn_cp  = self.get_cp(entities, i - 2)
+                        self.green_team.spawn_cp = self.get_cp(entities, i + 1)
+                        curr.disabled = False
+                    else: # Disable all other capture points.
+                        curr.disabled = True
+                else: # Disable all other capture points.
+                    curr.disabled = True
+                prev = curr
+        
         def get_cp_entities(self):
-            # generate positions
-
+            extensions = self.map_info.extensions
             map = self.map
-            blue_cp = []
-            green_cp = []
 
-            magnitude = 10
-            angle = random.uniform(START_ANGLE, END_ANGLE)
-            x, y = (0, random.randrange(64, 512 - 64))
+            # num_cps is the number of actual capturable points
+            # num_extra cps includes an extra 'spawn' cp, which is where players will spawn when they only have one capture point left as their color
+            # Players will spawn at the second closest capture point to the other side
+            num_cps = CP_COUNT
+            num_extra_cps = num_cps + 2
+            center = (num_extra_cps - 1) / 2
 
-            points = []
+            # The (x,y) positions of all capture points, plus two extra for spawn cps
+            # First blue cp and last green cp are spawn cps
+            cp_positions = []
 
-            square_1 = range(128)
-            square_2 = range(512 - 128, 512)
+            # First, get the (x,y) positions of capture points
+            if "tow_locations" in extensions: # Get from map extensions if specified
+                cp_positions = extensions["tow_locations"]
 
-            while True:
-                top = int(y) in square_1
-                bottom = int(y) in square_2
-                if top:
-                    angle = limit_angle(angle + FIX_ANGLE)
-                elif bottom:
-                    angle = limit_angle(angle - FIX_ANGLE)
-                else:
-                    angle = limit_angle(angle + random_up_down(DELTA_ANGLE))
-                magnitude += random_up_down(2)
-                magnitude = min(15, max(5, magnitude))
-                x2, y2 = get_point(x, y, magnitude, angle)
-                if x2 >= 511:
-                    break
-                x, y = x2, y2
-                points.append((int(x), int(y)))
+                num_extra_cps = len(cp_positions)
+                num_cps = num_extra_cps - 2
+                center = (num_extra_cps - 1) / 2
+            else: # Otherwise, generate a random curve
+                magnitude = 10
+                angle = random.uniform(START_ANGLE, END_ANGLE)
+                x, y = (0, random.randrange(64, 512 - 64))
 
-            move = 512 / CP_EXTRA_COUNT
-            offset = move / 2
+                square_1 = range(128)
+                square_2 = range(512 - 128, 512)
 
-            for i in range(CP_EXTRA_COUNT):
-                index = 0
+                points = []
+
+                # Generate points along a curve
                 while True:
-                    p_x, p_y = points[index]
-                    index += 1
-                    if p_x >= offset:
+                    top = int(y) in square_1
+                    bottom = int(y) in square_2
+                    if top:
+                        angle = limit_angle(angle + FIX_ANGLE)
+                    elif bottom:
+                        angle = limit_angle(angle - FIX_ANGLE)
+                    else:
+                        angle = limit_angle(angle + random_up_down(DELTA_ANGLE))
+                    magnitude += random_up_down(2)
+                    magnitude = min(15, max(5, magnitude))
+                    x2, y2 = get_point(x, y, magnitude, angle)
+                    if x2 >= 511:
                         break
-                if i < CP_EXTRA_COUNT / 2:
-                    blue_cp.append((p_x, p_y))
-                else:
-                    green_cp.append((p_x, p_y))
-                offset += move
+                    x, y = x2, y2
+                    points.append((int(x), int(y)))
+                
+                move = 512 / num_extra_cps
+                offset = move / 2
+                
+                # Take `num_extra_cps` evenly spaced points from that curve for our real positions
+                for i in range(num_extra_cps):
+                    index = 0
+                    while True:
+                        p_x, p_y = points[index]
+                        index += 1
+                        if p_x >= offset:
+                            break
+                    cp_positions.append(((p_x, p_y)))
+                    offset += move
 
-            # make entities
-
-            index = 0
-            entities = []
-
-            for i, (x, y) in enumerate(blue_cp):
-                entity = TugTerritory(index, self, *(x, y, map.get_z(x, y)))
-                entity.team = self.blue_team
-                if i == 0:
-                    self.blue_team.last_spawn = entity
+            # Create entities based on the positions we generated/loaded from map extensions
+            entities = [] # Does not include extra spawn CPs
+            entity_index = 0
+            
+            for i, (x, y) in enumerate(cp_positions):
+                entity = TugTerritory(entity_index, self, *(x, y, map.get_z(x, y)))
+                
+                if i == 0: # Blue extra spawn
                     entity.id = -1
-                else:
-                    entities.append(entity)
-                    index += 1
-
-            self.blue_team.cp = entities[-1]
-            self.blue_team.cp.disabled = False
-            self.blue_team.spawn_cp = entities[-2]
-
-            for i, (x, y) in enumerate(green_cp):
-                entity = TugTerritory(index, self, *(x, y, map.get_z(x, y)))
-                entity.team = self.green_team
-                if i == len(green_cp) - 1:
+                    self.blue_team.last_spawn = entity
+                    continue # Must not add extra spawns to entities list
+                elif i == len(cp_positions) - 1: # Green extra spawn
                     self.green_team.last_spawn = entity
-                    entity.id = index
-                else:
-                    entities.append(entity)
-                    index += 1
+                    continue # Must not add extra spawns to entities list
+                elif i < center: # Blue
+                    entity.team = self.blue_team
+                elif i > center: #Green
+                    entity.team = self.green_team
+                else: # Neutral
+                    entity.team = None
+                entities.append(entity)
+                entity_index += 1
 
-            self.green_team.cp = entities[-CP_COUNT // 2]
-            self.green_team.cp.disabled = False
-            self.green_team.spawn_cp = entities[-CP_COUNT // 2 + 1]
-
+            self.update_cps(entities)
             return entities
-
         def on_cp_capture(self, territory):
-            team = territory.team
-            if team.id:
-                move = -1
-            else:
-                move = 1
-            for team in [self.blue_team, self.green_team]:
-                try:
-                    team.cp = self.entities[get_index(team.cp.id + move)]
-                    team.cp.enable()
-                except IndexError:
-                    pass
-                try:
-                    team.spawn_cp = self.entities[get_index(
-                        team.spawn_cp.id + move)]
-                except IndexError:
-                    team.spawn_cp = team.last_spawn
-            cp = (self.blue_team.cp, self.green_team.cp)
-            for entity in self.entities:
-                if not entity.disabled and entity not in cp:
-                    entity.disable()
+            self.update_cps(self.entities)
 
     return TugProtocol, TugConnection


### PR DESCRIPTION
- Add support for setting custom capture points in the map.txt
- Add support for odd numbers of capture points (The center capture point will be neutral, and either team will have to capture it before they're able to capture each other's territories)
- Add option to have a fixed spawnpoint instead of spawning at the second-closest one to the enemy
- Ability to use custom spawning logic in the map.txt by adding `'tow_use_custom_spawn_function': True` to the extensions