### PR TITLE
Improve wheel CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Pypi Release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  call-workflow:
+    uses: ./.github/workflows/wheels.yml
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          # unpacks all CIBW artifacts into dist/
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # To test: repository-url: https://test.pypi.org/legacy/
+

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,6 +4,7 @@ on:
   release:
     types: [created]
 
+  workflow_call:
   workflow_dispatch:
 
 jobs:
@@ -11,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, ubuntu24.04-arm, macos-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -23,7 +24,8 @@ jobs:
         uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_BUILD_FRONTEND: "build"
-          CIBW_SKIP: "pp*"
+          CIBW_ARCHS: "auto64"
+          CIBW_ARCHS_MACOS: "universal2"
         with:
           output-dir: wheelhouse
 
@@ -38,11 +40,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Build sdist
         run: pipx run build --sdist
 
       - uses: actions/upload-artifact@v4
         with:
+          name: cibw-sdist
           path: dist/*.tar.gz
 


### PR DESCRIPTION
- add trusted publishing workflow (untested)
- remove 32bit builds
- add arm and macos builds

closes: #817
closes: #816
hopefully closes #815 too?