### PR TITLE
Fix bug in TOW script

### DIFF
--- a/piqueserver/game_modes/tow.py
+++ b/piqueserver/game_modes/tow.py
@@ -131,7 +131,7 @@ def apply_script(protocol, connection, config):
                         self.green_team.cp = curr
                         if move_spawn:
                             self.blue_team.spawn_cp  = self.get_cp(entities, i - 2)
-                            self.green_team.spawn_cp = self.get_cp(entities, i + 1)
+                            self.green_team.spawn_cp = self.get_cp(entities, i + 2)
                         else:
                             self.blue_team.spawn_cp = self.blue_team.last_spawn
                             self.green_team.spawn_cp = self.green_team.last_spawn


### PR DESCRIPTION
For uneven numbers of capture points, blue would spawn further away than green at the beginning of the game. Now they will spawn the same distance away from the center.