### PR TITLE
fix(bytes): replace `float('nan')` except with `NAN` from `libc.math`

### DIFF
--- a/pyspades/bytes.pxd
+++ b/pyspades/bytes.pxd
@@ -1,6 +1,7 @@
+from libc.math cimport NAN
+
 DEF INT_ERROR = -0xFFFFFFFF >> 1
 DEF LONG_LONG_ERROR = -0xFFFFFFFFFFFFFFFF >> 1
-DEF FLOAT_ERROR = float('nan')
 
 cdef extern from "<sstream>" namespace "std":
     cdef cppclass stringstream:
@@ -20,7 +21,7 @@ cdef class ByteReader:
                         except INT_ERROR
     cpdef long long readInt(self, bint unsigned = ?, bint big_endian = ?) \
                             except LONG_LONG_ERROR
-    cpdef float readFloat(self, bint big_endian = ?) except? FLOAT_ERROR
+    cpdef float readFloat(self, bint big_endian = ?) except? NAN
     cpdef bytes readString(self, int size = ?)
     cpdef ByteReader readReader(self, int size = ?)
     cpdef int dataLeft(self)

--- a/pyspades/bytes.pyx
+++ b/pyspades/bytes.pyx
@@ -20,6 +20,7 @@ The ByteReader/Bytewriter classes are used to read and write various data types
 from and to byte-like objects. This is used e.g. to read the contents of
 packets.
 """
+from libc.math cimport NAN
 
 cdef extern from "bytes_c.cpp":
     char read_byte(char * data)
@@ -56,7 +57,6 @@ class NoDataLeft(Exception):
 
 DEF INT_ERROR = -0xFFFFFFFF >> 1
 DEF LONG_LONG_ERROR = -0xFFFFFFFFFFFFFFFF >> 1
-DEF FLOAT_ERROR = float('nan')
 
 cdef class ByteReader:
     """Reads various data types from a bytes-like object"""
@@ -143,7 +143,7 @@ cdef class ByteReader:
         else:
             return read_int(pos, big_endian)
 
-    cpdef float readFloat(self, bint big_endian = True) except? FLOAT_ERROR:
+    cpdef float readFloat(self, bint big_endian = True) except? NAN:
         """read four bytes of data as floating point number
 
         Arguments:


### PR DESCRIPTION
Cython >= 3.1.0a1 breaks the build of bytes.{pxd,pyx}
```
      pyspades/bytes.cpp: In function 'float __pyx_f_8pyspades_5bytes_10ByteReader_readFloat(__pyx_obj_8pyspades_5bytes_ByteReader*, int, __pyx_opt_args_8pyspades_5bytes_10ByteReader_readFloat*)':
      pyspades/bytes.cpp:4819:13: error: cannot convert 'double(const char*) noexcept' to 'float' in assignment
       4819 |   __pyx_r = nan;
            |             ^~~
            |             |
            |             double(const char*) noexcept
      pyspades/bytes.cpp: In function 'PyObject* __pyx_pf_8pyspades_5bytes_10ByteReader_10readFloat(__pyx_obj_8pyspades_5bytes_ByteReader*, int)':
      pyspades/bytes.cpp:4929:125: error: invalid cast from type 'double (*)(const char*) noexcept' to type 'float'
       4929 |   __pyx_t_1 = __pyx_vtabptr_8pyspades_5bytes_ByteReader->readFloat(__pyx_v_self, 1, &__pyx_t_2); if (unlikely(__pyx_t_1 == ((float)nan) && PyErr_Occurred())) __PYX_ERR(0, 146, __pyx_L1_error)
            |                                                                                                                             ^~~~~~~~~~
```
I'm not sure what changed in Cython that caused this to happen (codegen regression?), but using NAN from libc.math fixes the issue.
