### PR TITLE
feat: improve handling of special characters in messages/names

### DIFF
--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -37,8 +37,8 @@ log = Logger()
 
 tc_data = loaders.TCState()
 
-# special characters to replace in chat messages
-MSG_SPECIAL_CHARACTER_MAP = str.maketrans({'\r': ' ', '\n': ' '})
+# messages that contain these characters will be dropped
+BANNED_MESSAGE_CHARACTERS = ['\r', '\n']
 
 def check_nan(*values) -> bool:
     for value in values:
@@ -638,7 +638,11 @@ class ServerConnection(BaseConnection):
             return
 
         value: str = contained.value
-        value = value.translate(MSG_SPECIAL_CHARACTER_MAP)
+        if any(c in BANNED_MESSAGE_CHARACTERS for c in value):
+            log.info("Dropped message with special characters from {name} (#{id})",
+                     name=self.name,
+                     id=self.player_id)
+            return
 
         if len(value) > 108:
             log.info("TOO LONG MESSAGE ({chars} chars) FROM {name} (#{id})",

--- a/pyspades/server.py
+++ b/pyspades/server.py
@@ -45,6 +45,9 @@ log = Logger()
 
 NICKNAME_SPECIAL_CHARS = str.maketrans({
     '%': '',
+    '#': '',
+    '\r': '',
+    '\n': '',
 })
 
 class MasterHostDict(TypedDict):

--- a/pyspades/server.py
+++ b/pyspades/server.py
@@ -357,6 +357,8 @@ class ServerProtocol(BaseProtocol):
         Returns the fixed name.
         '''
         name = name.translate(NICKNAME_SPECIAL_CHARS)
+        if not name:
+            name = 'Deuce'
         new_name = name
         names = [p.name.lower() for p in self.players.values()]
         i = 0

--- a/pyspades/server.py
+++ b/pyspades/server.py
@@ -43,6 +43,10 @@ from twisted.logger import Logger
 
 log = Logger()
 
+NICKNAME_SPECIAL_CHARS = str.maketrans({
+    '%': '',
+})
+
 class MasterHostDict(TypedDict):
     host: str
     port: int
@@ -342,14 +346,14 @@ class ServerProtocol(BaseProtocol):
             if player.team is not None:
                 player.spawn()
 
-    def get_name(self, name):
+    def get_name(self, name: str):
         '''
         Sanitizes `name` and modifies it so that it doesn't
         collide with other names connected to the server.
 
         Returns the fixed name.
         '''
-        name = name.replace('%', '')
+        name = name.translate(NICKNAME_SPECIAL_CHARS)
         new_name = name
         names = [p.name.lower() for p in self.players.values()]
         i = 0


### PR DESCRIPTION
Changes made:
- Made messages get dropped when containing special characters instead of replacing with a space
- Replaced `.replace()` with `.translate()` for handling special characters in player names
- Added `#`, `\r` and `\n` as special characters in player names
- Made empty names get replaced with "Deuce" instead of leaving them blank

Replaces #709
