### PR TITLE
Revert "feat(player): drop messages with special chars instead of replacing"

### DIFF
--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -37,8 +37,8 @@ log = Logger()
 
 tc_data = loaders.TCState()
 
-# messages that contain these characters will be dropped
-BANNED_MESSAGE_CHARACTERS = ['\r', '\n']
+# special characters to replace in chat messages
+MSG_SPECIAL_CHARACTER_MAP = str.maketrans({'\r': ' ', '\n': ' '})
 
 def check_nan(*values) -> bool:
     for value in values:
@@ -638,11 +638,7 @@ class ServerConnection(BaseConnection):
             return
 
         value: str = contained.value
-        if any(c in BANNED_MESSAGE_CHARACTERS for c in value):
-            log.info("Dropped message with special characters from {name} (#{id})",
-                     name=self.name,
-                     id=self.player_id)
-            return
+        value = value.translate(MSG_SPECIAL_CHARACTER_MAP)
 
         if len(value) > 108:
             log.info("TOO LONG MESSAGE ({chars} chars) FROM {name} (#{id})",


### PR DESCRIPTION
This reverts commit 28038b9ee2586399939c64e64f5faf7c2cec6dac.

It's very easy to copy line feeds into the clipboard, ignoring a player's message because of that does not make that player very happy.