### PR TITLE
implement AOS protocol kick reason extension (0xC2)

### DIFF
--- a/piqueserver/player.py
+++ b/piqueserver/player.py
@@ -66,7 +66,7 @@ class FeatureConnection(ServerConnection):
                 log.info('banned user {name} ({client_ip}) attempted to join',
                          name=name,
                          client_ip=client_ip)
-                self.disconnect(ERROR_BANNED)
+                self.disconnect(ERROR_BANNED, reason)
                 return
 
         manager = self.protocol.ban_manager
@@ -80,7 +80,7 @@ class FeatureConnection(ServerConnection):
                     client_ip=client_ip,
                     reason=reason
                 )
-                self.disconnect(ERROR_BANNED)
+                self.disconnect(ERROR_BANNED, reason)
                 return
 
         ServerConnection.on_connect(self)
@@ -333,7 +333,7 @@ class FeatureConnection(ServerConnection):
             log.info('{message}', message=message)
         # FIXME: Client should handle disconnect events the same way in both
         # main and initial loading network loops
-        self.disconnect(ERROR_KICKED)
+        self.disconnect(ERROR_KICKED, reason)
 
     def ban(self, reason=None, duration=None):
         reason = ': ' + reason if reason is not None else ''

--- a/piqueserver/server.py
+++ b/piqueserver/server.py
@@ -56,7 +56,8 @@ from piqueserver.scheduler import Scheduler
 from piqueserver.utils import as_deferred, EndCall
 from piqueserver.bansubscribe import bans_config_urls
 from pyspades.bytes import NoDataLeft
-from pyspades.constants import CTF_MODE, ERROR_SHUTDOWN, TC_MODE, EXTENSION_CHATTYPE
+from pyspades.constants import (CTF_MODE, ERROR_SHUTDOWN, TC_MODE,
+                                EXTENSION_CHATTYPE, EXTENSION_KICKREASON)
 from pyspades.master import MAX_SERVER_NAME_SIZE
 from pyspades.server import ServerProtocol, Team
 from pyspades.tools import make_server_identifier
@@ -275,7 +276,10 @@ class FeatureProtocol(ServerProtocol):
         self.win_count = itertools.count(1)
         self.bans = NetworkDict()
 
-        self.available_proto_extensions = [(EXTENSION_CHATTYPE, 1)]
+        self.available_proto_extensions = [
+            (EXTENSION_CHATTYPE, 1),
+            (EXTENSION_KICKREASON, 1),
+        ]
 
         # attempt to load a saved bans list
         try:

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -1251,6 +1251,20 @@ class ServerConnection(BaseConnection):
     def send_data(self, data):
         self.protocol.transport.write(data, self.address)
 
+    def disconnect(self, data: int = 0, reason: Optional[str] = None) -> None:
+        if reason:
+            self._send_kick_reason(reason)
+        super().disconnect(data)
+
+    def _send_kick_reason(self, reason: str) -> None:
+        if EXTENSION_KICKREASON not in self.proto_extensions:
+            return
+        msg = loaders.ChatMessage()
+        msg.player_id = 255
+        msg.chat_type = CHAT_SYSTEM
+        msg.value = reason[:MAX_CHAT_SIZE]
+        self.send_contained(msg)
+
     def send_chat(self, value: str, global_message: bool = False, custom_type: int = CHAT_ALL) -> None:
         if self.deaf:
             return

--- a/pyspades/protocol.py
+++ b/pyspades/protocol.py
@@ -37,7 +37,10 @@ class BaseConnection:
         if self.disconnected:
             return
         self.disconnected = True
-        self.peer.disconnect(data)
+        # disconnect_later waits for queued reliable packets to drain before
+        # sending DISCONNECT, so e.g. the kick-reason chat reaches the client
+        # before the disconnect notification fires.
+        self.peer.disconnect_later(data)
         self.protocol.remove_peer(self.peer)
         self.on_disconnect()
 


### PR DESCRIPTION
Implements the kick reason extension from the AOS 0.75 protocol
(piqueserver/aosprotocol#15). When a client advertises support for 0xC2,
the server now sends the kick/ban reason as a ChatMessage with
player_id=255 and chat_type=2 right before the ENet disconnect.

Compatible clients (BetterSpades, zerospades...) pick it up and display it
on the disconnect screen instead of the canned localized "You were kicked
from this server" text. Clients without the extension are unaffected —
the helper short-circuits and they fall back to existing behaviour.

Wired into kick() and the two on-connect ban paths in
piqueserver/player.py. The wire format helper send_kick_reason() lives on
ServerConnection in pyspades/player.py so any subclass can call it.

Tested against [zerospades](https://github.com/siecvi/zerospades): `/kick foo some reason` now shows `some reason`
on the disconnect screen.

My second PR after [this one](https://github.com/piqueserver/piqueserver/pull/841) (not yet merged) 😉

As new protocol extension are in discussion on the aloha discord, I thought it would be better to already implement existing ones first !
