### PR TITLE
fix(world): free PlayerType in Character.__dealloc__ to stop leak

### DIFF
--- a/pyspades/world.pyx
+++ b/pyspades/world.pyx
@@ -237,6 +237,9 @@ cdef class Character(Object):
             self.fall_callback(ret)
         return 0
 
+    def __dealloc__(self):
+        destroy_player(self.player)
+
     # properties
     property up:
         def __get__(self):


### PR DESCRIPTION
Hello guys :)

This PR is originally not from me but is to me, critical.
Idea is from totallynotaburner's pvx audit of pyspades object lifetimes: https://codeberg.org/totallynotaburner/pvx/commit/6c95d88d3a261f8de38caf721beac5be16dbfb30 The pvx commit fixes the same class of bug in a hand-written C ABI port; piqueserver uses Cython, so only the missing dealloc applies here.


Character allocated a PlayerType via create_player() in initialize() but never freed it — every player join/respawn leaked the struct. Grenade already had the symmetric destroy_grenade() in __dealloc__; Character was simply missing the matching cleanup.


