### PR TITLE
Proposal and PR, allow built in mandatory extension check.

### DIFF
--- a/piqueserver/config/config.toml
+++ b/piqueserver/config/config.toml
@@ -85,6 +85,20 @@ scripts = [
 # number of /login attempts allowed before players are auto-kicked (default: 1)
 login_retries = 3
 
+# per-extension state for the protocol extensions piqueserver knows about.
+# any known extension you don't list here is treated as "disabled".
+# valid states:
+#   "enabled"  - server advertises it; clients may use it.
+#   "disabled" - server doesn't advertise it.
+#   "required" - server advertises it and kicks clients that don't
+#                support it back. clients with the "kick reason"
+#                extension see a descriptive message; others get the
+#                generic wrong-version dialog.
+proto_extensions = [
+  ["chat type", "enabled"],
+  ["kick reason", "enabled"],
+]
+
 # MAP
 # maps listed in the rotation
 # these names are the name of the map vxl/txt files without the file extensions

--- a/piqueserver/config/config.toml
+++ b/piqueserver/config/config.toml
@@ -87,18 +87,6 @@ login_retries = 3
 
 # per-extension state for the protocol extensions piqueserver knows about.
 # any known extension you don't list here is treated as "disabled".
-# valid states:
-#   "enabled"  - server advertises it; clients may use it.
-#   "disabled" - server doesn't advertise it.
-#   "required" - server advertises it and kicks clients that don't
-#                support it back. clients with the "kick reason"
-#                extension see a descriptive message; others get the
-#                generic wrong-version dialog.
-proto_extensions = [
-  ["chat type", "enabled"],
-  ["kick reason", "enabled"],
-]
-
 # MAP
 # maps listed in the rotation
 # these names are the name of the map vxl/txt files without the file extensions

--- a/piqueserver/config/config.toml
+++ b/piqueserver/config/config.toml
@@ -85,8 +85,6 @@ scripts = [
 # number of /login attempts allowed before players are auto-kicked (default: 1)
 login_retries = 3
 
-# per-extension state for the protocol extensions piqueserver knows about.
-# any known extension you don't list here is treated as "disabled".
 # MAP
 # maps listed in the rotation
 # these names are the name of the map vxl/txt files without the file extensions

--- a/piqueserver/server.py
+++ b/piqueserver/server.py
@@ -317,7 +317,7 @@ class FeatureProtocol(ServerProtocol):
             for name, state in states.items()
             if state in ("enabled", "required")
         ]
-        self.required_proto_extensions = [
+        self.mandatory_proto_extensions = [
             KNOWN_PROTO_EXTENSIONS[name]
             for name, state in states.items()
             if state == "required"

--- a/piqueserver/server.py
+++ b/piqueserver/server.py
@@ -56,9 +56,7 @@ from piqueserver.scheduler import Scheduler
 from piqueserver.utils import as_deferred, EndCall
 from piqueserver.bansubscribe import bans_config_urls
 from pyspades.bytes import NoDataLeft
-from pyspades.constants import (CTF_MODE, ERROR_SHUTDOWN, TC_MODE,
-                                KNOWN_PROTO_EXTENSIONS,
-                                PROTO_EXTENSION_STATES)
+from pyspades.constants import CTF_MODE, ERROR_SHUTDOWN, TC_MODE
 from pyspades.master import MAX_SERVER_NAME_SIZE
 from pyspades.server import ServerProtocol, Team
 from pyspades.tools import make_server_identifier
@@ -185,35 +183,6 @@ master_hosts = config.option("master_hosts", [
 ])
 
 
-def _default_proto_extensions():
-    return [[name, "enabled"] for name in KNOWN_PROTO_EXTENSIONS]
-
-
-def _validate_proto_extensions(value):
-    if not isinstance(value, list):
-        return False
-    seen = set()
-    for entry in value:
-        if not (isinstance(entry, list) and len(entry) == 2):
-            return False
-        name, state = entry
-        if not (isinstance(name, str) and isinstance(state, str)):
-            return False
-        if name not in KNOWN_PROTO_EXTENSIONS:
-            return False
-        if state not in PROTO_EXTENSION_STATES:
-            return False
-        if name in seen:
-            return False
-        seen.add(name)
-    return True
-
-
-proto_extensions_option = config.option(
-    'proto_extensions',
-    default=_default_proto_extensions(),
-    validate=_validate_proto_extensions)
-
 def ensure_dir_exists(filename: str) -> None:
     d = os.path.dirname(filename)
     os.makedirs(d, exist_ok=True)
@@ -306,22 +275,6 @@ class FeatureProtocol(ServerProtocol):
         self.advance_on_win = int(advance_on_win.get())
         self.win_count = itertools.count(1)
         self.bans = NetworkDict()
-
-        # extensions absent from the config default to "disabled" so that
-        # introducing a new one upstream doesn't silently switch it on for
-        # existing servers.
-        states = {name: "disabled" for name in KNOWN_PROTO_EXTENSIONS}
-        states.update(dict(proto_extensions_option.get()))
-        self.available_proto_extensions = [
-            KNOWN_PROTO_EXTENSIONS[name]
-            for name, state in states.items()
-            if state in ("enabled", "required")
-        ]
-        self.mandatory_proto_extensions = [
-            KNOWN_PROTO_EXTENSIONS[name]
-            for name, state in states.items()
-            if state == "required"
-        ]
 
         # attempt to load a saved bans list
         try:

--- a/piqueserver/server.py
+++ b/piqueserver/server.py
@@ -812,7 +812,7 @@ class FeatureProtocol(ServerProtocol):
                     "map": map_name,
                     "game_mode": self.get_mode_name(),
                     "game_version": "0.75",
-                    "extensions": self.available_proto_extensions
+                    "extensions": self.extensions.advertised()
                 }
                 payload = json.dumps(entry).encode()
                 self.host.socket.send(address, payload)

--- a/piqueserver/server.py
+++ b/piqueserver/server.py
@@ -57,7 +57,8 @@ from piqueserver.utils import as_deferred, EndCall
 from piqueserver.bansubscribe import bans_config_urls
 from pyspades.bytes import NoDataLeft
 from pyspades.constants import (CTF_MODE, ERROR_SHUTDOWN, TC_MODE,
-                                EXTENSION_CHATTYPE, EXTENSION_KICKREASON)
+                                KNOWN_PROTO_EXTENSIONS,
+                                PROTO_EXTENSION_STATES)
 from pyspades.master import MAX_SERVER_NAME_SIZE
 from pyspades.server import ServerProtocol, Team
 from pyspades.tools import make_server_identifier
@@ -183,6 +184,36 @@ master_hosts = config.option("master_hosts", [
     {'host': 'master2.aos.coffee', 'port': 32886},
 ])
 
+
+def _default_proto_extensions():
+    return [[name, "enabled"] for name in KNOWN_PROTO_EXTENSIONS]
+
+
+def _validate_proto_extensions(value):
+    if not isinstance(value, list):
+        return False
+    seen = set()
+    for entry in value:
+        if not (isinstance(entry, list) and len(entry) == 2):
+            return False
+        name, state = entry
+        if not (isinstance(name, str) and isinstance(state, str)):
+            return False
+        if name not in KNOWN_PROTO_EXTENSIONS:
+            return False
+        if state not in PROTO_EXTENSION_STATES:
+            return False
+        if name in seen:
+            return False
+        seen.add(name)
+    return True
+
+
+proto_extensions_option = config.option(
+    'proto_extensions',
+    default=_default_proto_extensions(),
+    validate=_validate_proto_extensions)
+
 def ensure_dir_exists(filename: str) -> None:
     d = os.path.dirname(filename)
     os.makedirs(d, exist_ok=True)
@@ -276,9 +307,20 @@ class FeatureProtocol(ServerProtocol):
         self.win_count = itertools.count(1)
         self.bans = NetworkDict()
 
+        # extensions absent from the config default to "disabled" so that
+        # introducing a new one upstream doesn't silently switch it on for
+        # existing servers.
+        states = {name: "disabled" for name in KNOWN_PROTO_EXTENSIONS}
+        states.update(dict(proto_extensions_option.get()))
         self.available_proto_extensions = [
-            (EXTENSION_CHATTYPE, 1),
-            (EXTENSION_KICKREASON, 1),
+            KNOWN_PROTO_EXTENSIONS[name]
+            for name, state in states.items()
+            if state in ("enabled", "required")
+        ]
+        self.required_proto_extensions = [
+            KNOWN_PROTO_EXTENSIONS[name]
+            for name, state in states.items()
+            if state == "required"
         ]
 
         # attempt to load a saved bans list

--- a/pyspades/constants.py
+++ b/pyspades/constants.py
@@ -84,16 +84,6 @@ EXTENSION_NAMES = {
     EXTENSION_KICKREASON: "kick reason",
 }
 
-# protocol extensions piqueserver knows how to advertise, mapped to the
-# (extension_id, supported_version) the server speaks. consulted both for
-# building the advertised list and for enforcing the "required" state.
-KNOWN_PROTO_EXTENSIONS = {
-    "chat type": (EXTENSION_CHATTYPE, 1),
-    "kick reason": (EXTENSION_KICKREASON, 1),
-}
-
-PROTO_EXTENSION_STATES = ("enabled", "disabled", "required")
-
 CTF_MODE = 0
 TC_MODE = 1
 

--- a/pyspades/constants.py
+++ b/pyspades/constants.py
@@ -78,6 +78,22 @@ EXTENSION_PLAYERLIMIT = 192
 EXTENSION_CHATTYPE = 193
 EXTENSION_KICKREASON = 194
 
+EXTENSION_NAMES = {
+    EXTENSION_PLAYERLIMIT: "player limit",
+    EXTENSION_CHATTYPE: "chat type",
+    EXTENSION_KICKREASON: "kick reason",
+}
+
+# protocol extensions piqueserver knows how to advertise, mapped to the
+# (extension_id, supported_version) the server speaks. consulted both for
+# building the advertised list and for enforcing the "required" state.
+KNOWN_PROTO_EXTENSIONS = {
+    "chat type": (EXTENSION_CHATTYPE, 1),
+    "kick reason": (EXTENSION_KICKREASON, 1),
+}
+
+PROTO_EXTENSION_STATES = ("enabled", "disabled", "required")
+
 CTF_MODE = 0
 TC_MODE = 1
 

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -103,6 +103,7 @@ class ServerConnection(BaseConnection):
         self.rapids = RateLimiter(RAPID_WINDOW_ENTRIES, MAX_RAPID_SPEED)
         self.client_info = {}
         self.proto_extensions = {}  # type: Dict[int, int]
+        self._enabled_ext_warned = False
         self.line_build_start_pos = None
 
     def on_connect(self) -> None:
@@ -144,12 +145,21 @@ class ServerConnection(BaseConnection):
         log.debug("received extinfo {extinfo} from {player}",
                   extinfo=self.proto_extensions,
                   player=self)
-        self._enforce_mandatory_extensions()
+        if self._enforce_mandatory_extensions():
+            return
+        self._warn_missing_enabled_extensions()
 
     def _missing_mandatory_extensions(self):
         return [
-            (ext_id, min_ver)
-            for ext_id, min_ver in self.protocol.mandatory_proto_extensions
+            (ext_id, min_ver, reason, name)
+            for ext_id, min_ver, reason, name in self.protocol.extensions.mandatory()
+            if self.proto_extensions.get(ext_id, -1) < min_ver
+        ]
+
+    def _missing_enabled_extensions(self):
+        return [
+            (ext_id, min_ver, reason, name)
+            for ext_id, min_ver, reason, name in self.protocol.extensions.enabled_only()
             if self.proto_extensions.get(ext_id, -1) < min_ver
         ]
 
@@ -164,14 +174,15 @@ class ServerConnection(BaseConnection):
         if not missing:
             return False
         log.info("{player} kicked: missing mandatory protocol extensions {missing}",
-                 player=self, missing=missing)
+                 player=self,
+                 missing=[(name, min_ver, reason)
+                          for _, min_ver, reason, name in missing])
         if EXTENSION_KICKREASON in self.proto_extensions:
             self.disconnect(
                 ERROR_KICKED,
                 reason="Missing mandatory client extension: " + ", ".join(
-                    "{} v{}".format(EXTENSION_NAMES.get(ext_id, "id %d" % ext_id),
-                                    min_ver)
-                    for ext_id, min_ver in missing
+                    "{} v{} ({})".format(name, min_ver, reason)
+                    for _, min_ver, reason, name in missing
                 ),
             )
         else:
@@ -181,6 +192,35 @@ class ServerConnection(BaseConnection):
             # this server don't agree on the protocol".
             self.disconnect(ERROR_WRONG_VERSION)
         return True
+
+    def _warn_missing_enabled_extensions(self) -> None:
+        """Tell the player about each ENABLED-but-missing extension once.
+
+        Only fires for ENABLED extensions, not MANDATORY ones (those caused
+        a kick instead). Sent once per connection; cheap if there's nothing
+        to warn about.
+        """
+        if self.local or self.disconnected or self._enabled_ext_warned:
+            return
+        missing = self._missing_enabled_extensions()
+        if not missing:
+            return
+        self._enabled_ext_warned = True
+        for ext_id, min_ver, reason, name in missing:
+            client_ver = self.proto_extensions.get(ext_id)
+            version_note = ""
+            if client_ver is not None:
+                version_note = " (your client: v{}, needed: v{})".format(
+                    client_ver, min_ver)
+            log.info("{player}: missing enabled extension {name!r}{ver} ({reason})",
+                     player=self, name=name, ver=version_note, reason=reason)
+            self.send_chat_warning(
+                'Heads up: this server uses the "{name}" protocol '
+                'extension ({reason}). Your client lacks it{ver}, so '
+                "related features won't work for you. Please update "
+                "your client, or open a ticket with its authors to add "
+                "support.".format(name=name, reason=reason,
+                                  ver=version_note))
 
     @register_packet_handler(loaders.ExistingPlayer)
     @register_packet_handler(loaders.ShortPlayerData)
@@ -201,6 +241,7 @@ class ServerConnection(BaseConnection):
         # (e.g. vanilla 0.75) — by now we've waited long enough for one.
         if self._enforce_mandatory_extensions():
             return
+        self._warn_missing_enabled_extensions()
 
         old_team = self.team
         team = self.protocol.teams[contained.team]
@@ -772,12 +813,12 @@ class ServerConnection(BaseConnection):
         # whether to kick them.
         skip_old_openspades = (contained.client == 'o'
                                and contained.version <= (0, 1, 3)
-                               and not self.protocol.mandatory_proto_extensions)
+                               and not self.protocol.extensions.mandatory())
         if skip_old_openspades:
             log.debug("not sending version request to OpenSpades <= 0.1.3")
         else:
             ext_info = loaders.ProtocolExtensionInfo()
-            ext_info.extensions = self.protocol.available_proto_extensions
+            ext_info.extensions = self.protocol.extensions.advertised()
             self.send_contained(ext_info)
         self.on_client_info()
 

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -218,7 +218,11 @@ class ServerConnection(BaseConnection):
                     client_ver, min_ver)
             log.info("{player}: missing enabled extension {name!r}{ver} ({reason})",
                      player=self, name=name, ver=version_note, reason=reason)
-            self.send_chat_warning(
+            # plain CHAT_SYSTEM rather than CHAT_WARNING: yellow toasts are
+            # disruptive at first spawn, especially when several extensions
+            # are missing -- chat-line delivery is less annoying and stays
+            # readable in scrollback.
+            self.send_chat(
                 'Heads up: this server uses the "{name}" protocol '
                 'extension ({reason}). Your client lacks it{ver}, so '
                 "related features won't work for you. Please update "

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -164,13 +164,13 @@ class ServerConnection(BaseConnection):
     def _enforce_mandatory_extensions(self) -> bool:
         """Kick the player if any mandatory extension is missing.
 
-        Returns True if a kick was issued. Uses ERROR_WRONG_VERSION rather
-        than ERROR_KICKED with a custom reason: the client hasn't reached
-        the state where it processes ChatMessage packets at this point in
-        the handshake, so any custom kick-reason text we sent would be
-        dropped on the floor. "Incompatible client protocol version" is
-        the next-best built-in dialog and accurately describes the
-        situation.
+        Returns True if a kick was issued. Falls back to ERROR_WRONG_VERSION
+        because vanilla and v1 kick-reason clients do not process the
+        kick-reason ChatMessage during the handshake. For clients that
+        negotiated kick-reason v2 (see AOS extensions spec, packet 0xC2),
+        we additionally send a descriptive CHAT_SYSTEM reason before the
+        disconnect so the failure surfaces in the client UI instead of as
+        a generic "incompatible version" dialog.
         """
         if self.local or self.disconnected:
             return False
@@ -181,8 +181,39 @@ class ServerConnection(BaseConnection):
                  player=self,
                  missing=[(name, min_ver, reason)
                           for _, min_ver, reason, name in missing])
+        self._send_mandatory_kick_reason(missing)
         self.disconnect(ERROR_WRONG_VERSION)
         return True
+
+    def _send_mandatory_kick_reason(self, missing) -> None:
+        """Tell v2-aware clients exactly which extension(s) they lack.
+
+        Per the kick-reason v2 spec, v2 clients accept this packet in any
+        state and use its payload as the disconnect reason. v1 clients are
+        not required to process it pre-join, so we gate on v2.
+        """
+        if self.proto_extensions.get(EXTENSION_KICKREASON, 0) < 2:
+            return
+        parts = []
+        for ext_id, min_ver, _, name in missing:
+            client_ver = self.proto_extensions.get(ext_id)
+            if client_ver is None:
+                parts.append('"{name}" v{ver}+'.format(name=name, ver=min_ver))
+            else:
+                parts.append('"{name}" v{ver}+ (have v{have})'.format(
+                    name=name, ver=min_ver, have=client_ver))
+        prefix = ("Required extension: " if len(parts) == 1
+                  else "Required extensions: ")
+        suffix = ". Update your client."
+        body = ", ".join(parts)
+        budget = MAX_CHAT_SIZE - len(prefix) - len(suffix)
+        if budget > 3 and len(body) > budget:
+            body = body[:budget - 3] + "..."
+        msg = loaders.ChatMessage()
+        msg.player_id = 255
+        msg.chat_type = CHAT_SYSTEM
+        msg.value = (prefix + body + suffix)[:MAX_CHAT_SIZE]
+        self.send_contained(msg)
 
     def _warn_missing_enabled_extensions(self) -> None:
         """Tell the player once about each ENABLED-but-missing extension.

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -198,11 +198,12 @@ class ServerConnection(BaseConnection):
         return True
 
     def _warn_missing_enabled_extensions(self) -> None:
-        """Tell the player about each ENABLED-but-missing extension once.
+        """Tell the player once about each ENABLED-but-missing extension.
 
-        Only fires for ENABLED extensions, not MANDATORY ones (those caused
-        a kick instead). Sent once per connection; cheap if there's nothing
-        to warn about.
+        Sends one short chat line per missing extension (name + truncated
+        reason + optional version note) followed by a single call-to-action
+        line, instead of a multi-line paragraph per extension. The full
+        reason is preserved in the server log for admin context.
         """
         if self.local or self.disconnected or self._enabled_ext_warned:
             return
@@ -210,25 +211,27 @@ class ServerConnection(BaseConnection):
         if not missing:
             return
         self._enabled_ext_warned = True
+        # chat lines wrap at MAX_CHAT_SIZE; budget the reason so each entry
+        # stays on a single line in typical cases.
+        reason_budget = 50
         for ext_id, min_ver, reason, name in missing:
             client_ver = self.proto_extensions.get(ext_id)
             version_note = ""
             if client_ver is not None:
-                version_note = " (your client: v{}, needed: v{})".format(
+                version_note = " [yours v{}, needs v{}]".format(
                     client_ver, min_ver)
             log.info("{player}: missing enabled extension {name!r}{ver} ({reason})",
                      player=self, name=name, ver=version_note, reason=reason)
-            # plain CHAT_SYSTEM rather than CHAT_WARNING: yellow toasts are
-            # disruptive at first spawn, especially when several extensions
-            # are missing -- chat-line delivery is less annoying and stays
-            # readable in scrollback.
+            if len(reason) > reason_budget:
+                short_reason = reason[:reason_budget - 3] + "..."
+            else:
+                short_reason = reason
             self.send_chat(
-                'Heads up: this server uses the "{name}" protocol '
-                'extension ({reason}). Your client lacks it{ver}, so '
-                "related features won't work for you. Please update "
-                "your client, or open a ticket with its authors to add "
-                "support.".format(name=name, reason=reason,
-                                  ver=version_note))
+                'Missing protocol extension: "{name}" ({reason}){ver}'
+                .format(name=name, reason=short_reason, ver=version_note))
+        self.send_chat(
+            "Update your client or open a ticket with its authors to "
+            "add support.")
 
     @register_packet_handler(loaders.ExistingPlayer)
     @register_packet_handler(loaders.ShortPlayerData)

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -145,13 +145,7 @@ class ServerConnection(BaseConnection):
         log.debug("received extinfo {extinfo} from {player}",
                   extinfo=self.proto_extensions,
                   player=self)
-        # the actual mandatory-extension kick fires post-StateData (see
-        # send_map): OpenSpades discards ChatMessage packets received during
-        # the Connecting / ReceivingMap phases, so a kick-reason sent here
-        # never reaches the disconnect dialog. holding the kick until the
-        # client transitions to NetClientStatusConnected costs the rejected
-        # client a map download but is the only point where the reason
-        # actually shows up.
+        self._enforce_mandatory_extensions()
 
     def _missing_mandatory_extensions(self):
         return [
@@ -170,7 +164,13 @@ class ServerConnection(BaseConnection):
     def _enforce_mandatory_extensions(self) -> bool:
         """Kick the player if any mandatory extension is missing.
 
-        Returns True if a kick was issued.
+        Returns True if a kick was issued. Uses ERROR_WRONG_VERSION rather
+        than ERROR_KICKED with a custom reason: the client hasn't reached
+        the state where it processes ChatMessage packets at this point in
+        the handshake, so any custom kick-reason text we sent would be
+        dropped on the floor. "Incompatible client protocol version" is
+        the next-best built-in dialog and accurately describes the
+        situation.
         """
         if self.local or self.disconnected:
             return False
@@ -181,14 +181,7 @@ class ServerConnection(BaseConnection):
                  player=self,
                  missing=[(name, min_ver, reason)
                           for _, min_ver, reason, name in missing])
-        reason = "Missing mandatory client extension: " + ", ".join(
-            "{} v{} ({})".format(name, min_ver, r)
-            for _, min_ver, r, name in missing
-        )
-        # piqueserver's kick() already handles the kick-reason extension
-        # and the wrong-version fallback; silent=True skips the "X was
-        # kicked" broadcast since the player has no name yet.
-        self.kick(reason, silent=True)
+        self.disconnect(ERROR_WRONG_VERSION)
         return True
 
     def _warn_missing_enabled_extensions(self) -> None:
@@ -1330,14 +1323,6 @@ class ServerConnection(BaseConnection):
                 packet = enet.Packet(bytes(data), enet.PACKET_FLAG_RELIABLE)
                 self.peer.send(0, packet)
             self.saved_loaders = None
-            # the StateData we just queued transitions the client to
-            # NetClientStatusConnected, the first state where ChatMessage
-            # packets are honored as kick reasons. queueing the kick chat
-            # + DISCONNECT now means the client processes them in order
-            # (StateData -> Connected -> ChatMessage -> DISCONNECT), so the
-            # reason actually surfaces in the disconnect dialog.
-            if self._enforce_mandatory_extensions():
-                return
             self.on_join()
             return
         for _ in range(10):

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -181,20 +181,14 @@ class ServerConnection(BaseConnection):
                  player=self,
                  missing=[(name, min_ver, reason)
                           for _, min_ver, reason, name in missing])
-        if EXTENSION_KICKREASON in self.proto_extensions:
-            self.disconnect(
-                ERROR_KICKED,
-                reason="Missing mandatory client extension: " + ", ".join(
-                    "{} v{} ({})".format(name, min_ver, reason)
-                    for _, min_ver, reason, name in missing
-                ),
-            )
-        else:
-            # vanilla and other clients without the kick-reason extension
-            # have no way to surface a custom string, so reuse the existing
-            # "wrong version" dialog — it already conveys "your client and
-            # this server don't agree on the protocol".
-            self.disconnect(ERROR_WRONG_VERSION)
+        reason = "Missing mandatory client extension: " + ", ".join(
+            "{} v{} ({})".format(name, min_ver, r)
+            for _, min_ver, r, name in missing
+        )
+        # piqueserver's kick() already handles the kick-reason extension
+        # and the wrong-version fallback; silent=True skips the "X was
+        # kicked" broadcast since the player has no name yet.
+        self.kick(reason, silent=True)
         return True
 
     def _warn_missing_enabled_extensions(self) -> None:

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -145,14 +145,18 @@ class ServerConnection(BaseConnection):
         log.debug("received extinfo {extinfo} from {player}",
                   extinfo=self.proto_extensions,
                   player=self)
-        # both the mandatory-kick and the soft-warn are deferred to
-        # on_new_player_recieved: clients (notably OpenSpades) discard
-        # ChatMessages received during the connect/map-loading phase,
-        # which means a kick-reason sent here never surfaces in the
-        # disconnect dialog. waiting until the team-join packet costs
-        # the rejected client a map download, but it's the only point
-        # we can be sure chat -- including the kick reason -- actually
-        # reaches the user.
+        # kick as soon as the handshake completes -- waiting until the
+        # team-join packet would let a misbehaving client occupy a slot
+        # indefinitely by simply never sending ExistingPlayer.
+        #
+        # caveat: OpenSpades (and probably other clients) only surface a
+        # kick-reason ChatMessage when received in the NetClientStatusConnected
+        # state, which it only reaches after StateData -- so a handshake-time
+        # kick will render as the generic "kicked from this server" dialog
+        # there even though the kick-reason packet is sent. clients that
+        # buffer chat earlier still get the reason. the soft-warn path stays
+        # deferred to on_new_player_recieved where chat is reliably visible.
+        self._enforce_mandatory_extensions()
 
     def _missing_mandatory_extensions(self):
         return [

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -145,18 +145,13 @@ class ServerConnection(BaseConnection):
         log.debug("received extinfo {extinfo} from {player}",
                   extinfo=self.proto_extensions,
                   player=self)
-        # kick as soon as the handshake completes -- waiting until the
-        # team-join packet would let a misbehaving client occupy a slot
-        # indefinitely by simply never sending ExistingPlayer.
-        #
-        # caveat: OpenSpades (and probably other clients) only surface a
-        # kick-reason ChatMessage when received in the NetClientStatusConnected
-        # state, which it only reaches after StateData -- so a handshake-time
-        # kick will render as the generic "kicked from this server" dialog
-        # there even though the kick-reason packet is sent. clients that
-        # buffer chat earlier still get the reason. the soft-warn path stays
-        # deferred to on_new_player_recieved where chat is reliably visible.
-        self._enforce_mandatory_extensions()
+        # the actual mandatory-extension kick fires post-StateData (see
+        # send_map): OpenSpades discards ChatMessage packets received during
+        # the Connecting / ReceivingMap phases, so a kick-reason sent here
+        # never reaches the disconnect dialog. holding the kick until the
+        # client transitions to NetClientStatusConnected costs the rejected
+        # client a map download but is the only point where the reason
+        # actually shows up.
 
     def _missing_mandatory_extensions(self):
         return [
@@ -1341,6 +1336,14 @@ class ServerConnection(BaseConnection):
                 packet = enet.Packet(bytes(data), enet.PACKET_FLAG_RELIABLE)
                 self.peer.send(0, packet)
             self.saved_loaders = None
+            # the StateData we just queued transitions the client to
+            # NetClientStatusConnected, the first state where ChatMessage
+            # packets are honored as kick reasons. queueing the kick chat
+            # + DISCONNECT now means the client processes them in order
+            # (StateData -> Connected -> ChatMessage -> DISCONNECT), so the
+            # reason actually surfaces in the disconnect dialog.
+            if self._enforce_mandatory_extensions():
+                return
             self.on_join()
             return
         for _ in range(10):

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -144,6 +144,43 @@ class ServerConnection(BaseConnection):
         log.debug("received extinfo {extinfo} from {player}",
                   extinfo=self.proto_extensions,
                   player=self)
+        self._enforce_required_extensions()
+
+    def _missing_required_extensions(self):
+        return [
+            (ext_id, min_ver)
+            for ext_id, min_ver in self.protocol.required_proto_extensions
+            if self.proto_extensions.get(ext_id, -1) < min_ver
+        ]
+
+    def _enforce_required_extensions(self) -> bool:
+        """Kick the player if any required extension is missing.
+
+        Returns True if a kick was issued.
+        """
+        if self.local or self.disconnected:
+            return False
+        missing = self._missing_required_extensions()
+        if not missing:
+            return False
+        log.info("{player} kicked: missing required protocol extensions {missing}",
+                 player=self, missing=missing)
+        if EXTENSION_KICKREASON in self.proto_extensions:
+            self.disconnect(
+                ERROR_KICKED,
+                reason="Missing required client extension: " + ", ".join(
+                    "{} v{}".format(EXTENSION_NAMES.get(ext_id, "id %d" % ext_id),
+                                    min_ver)
+                    for ext_id, min_ver in missing
+                ),
+            )
+        else:
+            # vanilla and other clients without the kick-reason extension
+            # have no way to surface a custom string, so reuse the existing
+            # "wrong version" dialog — it already conveys "your client and
+            # this server don't agree on the protocol".
+            self.disconnect(ERROR_WRONG_VERSION)
+        return True
 
     @register_packet_handler(loaders.ExistingPlayer)
     @register_packet_handler(loaders.ShortPlayerData)
@@ -158,6 +195,11 @@ class ServerConnection(BaseConnection):
                  " in limbo or spectator mode"),
                 player=self
             )
+            return
+
+        # catches clients that never sent ProtocolExtensionInfo at all
+        # (e.g. vanilla 0.75) — by now we've waited long enough for one.
+        if self._enforce_required_extensions():
             return
 
         old_team = self.team

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -725,7 +725,13 @@ class ServerConnection(BaseConnection):
 
         # send extension info to clients that support this packet.
         # skip openspades <= 0.1.3 https://github.com/piqueserver/piqueserver/issues/504
-        if contained.client == 'o' and contained.version <= (0, 1, 3):
+        # unless the server requires extensions, in which case those clients
+        # also need a chance to advertise what they support before we decide
+        # whether to kick them.
+        skip_old_openspades = (contained.client == 'o'
+                               and contained.version <= (0, 1, 3)
+                               and not self.protocol.required_proto_extensions)
+        if skip_old_openspades:
             log.debug("not sending version request to OpenSpades <= 0.1.3")
         else:
             ext_info = loaders.ProtocolExtensionInfo()

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -144,31 +144,31 @@ class ServerConnection(BaseConnection):
         log.debug("received extinfo {extinfo} from {player}",
                   extinfo=self.proto_extensions,
                   player=self)
-        self._enforce_required_extensions()
+        self._enforce_mandatory_extensions()
 
-    def _missing_required_extensions(self):
+    def _missing_mandatory_extensions(self):
         return [
             (ext_id, min_ver)
-            for ext_id, min_ver in self.protocol.required_proto_extensions
+            for ext_id, min_ver in self.protocol.mandatory_proto_extensions
             if self.proto_extensions.get(ext_id, -1) < min_ver
         ]
 
-    def _enforce_required_extensions(self) -> bool:
-        """Kick the player if any required extension is missing.
+    def _enforce_mandatory_extensions(self) -> bool:
+        """Kick the player if any mandatory extension is missing.
 
         Returns True if a kick was issued.
         """
         if self.local or self.disconnected:
             return False
-        missing = self._missing_required_extensions()
+        missing = self._missing_mandatory_extensions()
         if not missing:
             return False
-        log.info("{player} kicked: missing required protocol extensions {missing}",
+        log.info("{player} kicked: missing mandatory protocol extensions {missing}",
                  player=self, missing=missing)
         if EXTENSION_KICKREASON in self.proto_extensions:
             self.disconnect(
                 ERROR_KICKED,
-                reason="Missing required client extension: " + ", ".join(
+                reason="Missing mandatory client extension: " + ", ".join(
                     "{} v{}".format(EXTENSION_NAMES.get(ext_id, "id %d" % ext_id),
                                     min_ver)
                     for ext_id, min_ver in missing
@@ -199,7 +199,7 @@ class ServerConnection(BaseConnection):
 
         # catches clients that never sent ProtocolExtensionInfo at all
         # (e.g. vanilla 0.75) — by now we've waited long enough for one.
-        if self._enforce_required_extensions():
+        if self._enforce_mandatory_extensions():
             return
 
         old_team = self.team
@@ -772,7 +772,7 @@ class ServerConnection(BaseConnection):
         # whether to kick them.
         skip_old_openspades = (contained.client == 'o'
                                and contained.version <= (0, 1, 3)
-                               and not self.protocol.required_proto_extensions)
+                               and not self.protocol.mandatory_proto_extensions)
         if skip_old_openspades:
             log.debug("not sending version request to OpenSpades <= 0.1.3")
         else:

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -145,13 +145,14 @@ class ServerConnection(BaseConnection):
         log.debug("received extinfo {extinfo} from {player}",
                   extinfo=self.proto_extensions,
                   player=self)
-        # mandatory enforcement runs as early as we can confirm what the
-        # client speaks, so we kick before the player finishes loading.
-        # the soft-warn path is deferred until the player has actually
-        # joined a team or spectator -- chat sent mid-handshake gets lost
-        # in the loading-screen noise, and a toast firing before the
-        # player has any context is more confusing than useful.
-        self._enforce_mandatory_extensions()
+        # both the mandatory-kick and the soft-warn are deferred to
+        # on_new_player_recieved: clients (notably OpenSpades) discard
+        # ChatMessages received during the connect/map-loading phase,
+        # which means a kick-reason sent here never surfaces in the
+        # disconnect dialog. waiting until the team-join packet costs
+        # the rejected client a map download, but it's the only point
+        # we can be sure chat -- including the kick reason -- actually
+        # reaches the user.
 
     def _missing_mandatory_extensions(self):
         return [

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -145,9 +145,13 @@ class ServerConnection(BaseConnection):
         log.debug("received extinfo {extinfo} from {player}",
                   extinfo=self.proto_extensions,
                   player=self)
-        if self._enforce_mandatory_extensions():
-            return
-        self._warn_missing_enabled_extensions()
+        # mandatory enforcement runs as early as we can confirm what the
+        # client speaks, so we kick before the player finishes loading.
+        # the soft-warn path is deferred until the player has actually
+        # joined a team or spectator -- chat sent mid-handshake gets lost
+        # in the loading-screen noise, and a toast firing before the
+        # player has any context is more confusing than useful.
+        self._enforce_mandatory_extensions()
 
     def _missing_mandatory_extensions(self):
         return [

--- a/pyspades/proto_extensions.py
+++ b/pyspades/proto_extensions.py
@@ -1,4 +1,4 @@
-# Copyright (c) Mathias Kaerlev 2011-2012.
+# Copyright (c) 2026 Francois ND and the Piqueserver Authors
 
 # This file is part of pyspades.
 

--- a/pyspades/proto_extensions.py
+++ b/pyspades/proto_extensions.py
@@ -1,0 +1,136 @@
+# Copyright (c) Mathias Kaerlev 2011-2012.
+
+# This file is part of pyspades.
+
+# pyspades is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# pyspades is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with pyspades.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Per-protocol-extension policy registry.
+
+Scripts call ``protocol.extensions.enable(...)`` / ``.mandate(...)`` /
+``.disable(...)`` to declare what the server speaks. The registry keeps a
+single state per extension and applies a priority rule so that two scripts
+can coexist without trampling each other's intent:
+
+* ``DISABLED`` is a veto. Going ``DISABLED <-> ENABLED|MANDATORY`` raises.
+* For the ``ENABLED``/``MANDATORY`` pair, the stricter state wins. A later
+  ``mandate`` over an ``enable`` upgrades; a later ``enable`` over a
+  ``mandate`` is silently dropped (the stronger commitment stands).
+* Re-asserting the same state simply refreshes the reason/version.
+"""
+
+from typing import Dict, List, Optional, Tuple
+
+from twisted.logger import Logger
+
+from pyspades.constants import EXTENSION_NAMES
+
+log = Logger()
+
+ENABLED = "enabled"
+MANDATORY = "mandatory"
+DISABLED = "disabled"
+
+_RANK = {DISABLED: 0, ENABLED: 1, MANDATORY: 2}
+
+
+class ProtoExtensionPolicyConflict(RuntimeError):
+    """Raised when a registry call would weaken an existing commitment.
+
+    Specifically: any transition that crosses the ``DISABLED`` boundary.
+    Same-state re-assertions and ``ENABLED`` <-> ``MANDATORY`` moves are
+    handled silently.
+    """
+
+
+def _name(ext_id: int) -> str:
+    return EXTENSION_NAMES.get(ext_id, "id {}".format(ext_id))
+
+
+class ProtoExtensionRegistry:
+    def __init__(self) -> None:
+        # ext_id -> (state, version, reason)
+        self._policies: Dict[int, Tuple[str, int, str]] = {}
+
+    def enable(self, ext_id: int, reason: str, version: int = 1) -> None:
+        self._set(ext_id, ENABLED, version, reason)
+
+    def mandate(self, ext_id: int, reason: str, version: int = 1) -> None:
+        self._set(ext_id, MANDATORY, version, reason)
+
+    def disable(self, ext_id: int, reason: str) -> None:
+        self._set(ext_id, DISABLED, 0, reason)
+
+    def policy_of(self, ext_id: int) -> Optional[str]:
+        entry = self._policies.get(ext_id)
+        return entry[0] if entry else None
+
+    def advertised(self) -> List[Tuple[int, int]]:
+        return [(ext_id, ver)
+                for ext_id, (state, ver, _) in self._policies.items()
+                if state in (ENABLED, MANDATORY)]
+
+    def mandatory(self) -> List[Tuple[int, int, str, str]]:
+        return [(ext_id, ver, reason, _name(ext_id))
+                for ext_id, (state, ver, reason) in self._policies.items()
+                if state == MANDATORY]
+
+    def enabled_only(self) -> List[Tuple[int, int, str, str]]:
+        return [(ext_id, ver, reason, _name(ext_id))
+                for ext_id, (state, ver, reason) in self._policies.items()
+                if state == ENABLED]
+
+    def policies(self) -> Dict[int, Tuple[str, int, str]]:
+        return dict(self._policies)
+
+    def _set(self, ext_id: int, new_state: str, version: int,
+             reason: str) -> None:
+        existing = self._policies.get(ext_id)
+        if existing is None:
+            self._policies[ext_id] = (new_state, version, reason)
+            return
+
+        prev_state, prev_version, prev_reason = existing
+
+        # the DISABLED veto cannot coexist with an active state in either
+        # direction. catch the bug at boot rather than guessing what the
+        # author meant.
+        if (new_state == DISABLED) != (prev_state == DISABLED):
+            raise ProtoExtensionPolicyConflict(
+                "cannot {new} extension {name!r}: previously {prev} with "
+                "reason: {prev_reason!r}; new reason: {reason!r}".format(
+                    new=new_state, prev=prev_state,
+                    name=_name(ext_id),
+                    prev_reason=prev_reason, reason=reason))
+
+        if new_state == DISABLED:
+            # both DISABLED: idempotent refresh.
+            self._policies[ext_id] = (DISABLED, 0, reason)
+            return
+
+        # both in {ENABLED, MANDATORY}: stricter state wins.
+        if _RANK[new_state] > _RANK[prev_state]:
+            log.debug(
+                "extension {name!r} upgraded {prev}->{new}; reason replaced",
+                name=_name(ext_id), prev=prev_state, new=new_state)
+            self._policies[ext_id] = (new_state, version, reason)
+        elif _RANK[new_state] == _RANK[prev_state]:
+            # same level: latest assertion overwrites reason/version.
+            self._policies[ext_id] = (new_state, version, reason)
+        else:
+            # MANDATORY beats a later ENABLED: keep the stronger commitment.
+            log.debug(
+                "extension {name!r} kept {prev}; ignoring later {new} "
+                "(reason: {reason!r})",
+                name=_name(ext_id), prev=prev_state, new=new_state,
+                reason=reason)

--- a/pyspades/server.py
+++ b/pyspades/server.py
@@ -104,7 +104,9 @@ class ServerProtocol(BaseProtocol):
         # extension's state with mandate() without hitting a conflict.
         self.extensions = ProtoExtensionRegistry()
         self.extensions.enable(EXTENSION_KICKREASON,
-                               reason="QoL: structured kick messages")
+                               reason=("QoL: structured kick messages, "
+                                       "v2 also during handshake/map transfer"),
+                               version=2)
         self.extensions.enable(EXTENSION_CHATTYPE,
                                reason="QoL: OpenSpades-style chat coloring")
 

--- a/pyspades/server.py
+++ b/pyspades/server.py
@@ -16,7 +16,7 @@
 # along with pyspades.  If not, see <http://www.gnu.org/licenses/>.
 
 import random
-from typing import List, TypedDict
+from typing import List, Tuple, TypedDict
 import warnings
 from itertools import product
 import enet
@@ -85,6 +85,12 @@ class ServerProtocol(BaseProtocol):
     version = GAME_VERSION
     respawn_waves = False
     master_hosts: List[MasterHostDict]
+    # (extension_id, version) lists derived from the per-extension state
+    # configuration. available is what the server advertises to clients;
+    # required is the subset clients must advertise back or be kicked.
+    # both default to empty so embedders/tests don't have to set them.
+    available_proto_extensions: List[Tuple[int, int]] = []
+    required_proto_extensions: List[Tuple[int, int]] = []
 
     def __init__(self, *arg, **kw):
         # +2 to allow server->master and master->server connection since enet

--- a/pyspades/server.py
+++ b/pyspades/server.py
@@ -27,7 +27,9 @@ import traceback
 from pyspades.protocol import BaseProtocol
 from pyspades.constants import (
     CTF_MODE, TC_MODE, GAME_VERSION, MIN_TERRITORY_COUNT, MAX_TERRITORY_COUNT,
-    UPDATE_FREQUENCY, UPDATE_FPS, NETWORK_FPS)
+    UPDATE_FREQUENCY, UPDATE_FPS, NETWORK_FPS,
+    EXTENSION_CHATTYPE, EXTENSION_KICKREASON)
+from pyspades.proto_extensions import ProtoExtensionRegistry
 from pyspades.types import IDPool
 from pyspades.master import MasterPool
 from pyspades.team import Team
@@ -85,12 +87,7 @@ class ServerProtocol(BaseProtocol):
     version = GAME_VERSION
     respawn_waves = False
     master_hosts: List[MasterHostDict]
-    # (extension_id, version) lists derived from the per-extension state
-    # configuration. available is what the server advertises to clients;
-    # mandatory is the subset clients must advertise back or be kicked.
-    # both default to empty so embedders/tests don't have to set them.
-    available_proto_extensions: List[Tuple[int, int]] = []
-    mandatory_proto_extensions: List[Tuple[int, int]] = []
+    extensions: ProtoExtensionRegistry
 
     def __init__(self, *arg, **kw):
         # +2 to allow server->master and master->server connection since enet
@@ -102,6 +99,14 @@ class ServerProtocol(BaseProtocol):
         self.entities = []
         self.players = {}
         self.player_ids = IDPool()
+
+        # defaults run before scripts so that scripts may upgrade an
+        # extension's state with mandate() without hitting a conflict.
+        self.extensions = ProtoExtensionRegistry()
+        self.extensions.enable(EXTENSION_KICKREASON,
+                               reason="QoL: structured kick messages")
+        self.extensions.enable(EXTENSION_CHATTYPE,
+                               reason="QoL: OpenSpades-style chat coloring")
 
         self._create_teams()
 

--- a/pyspades/server.py
+++ b/pyspades/server.py
@@ -87,10 +87,10 @@ class ServerProtocol(BaseProtocol):
     master_hosts: List[MasterHostDict]
     # (extension_id, version) lists derived from the per-extension state
     # configuration. available is what the server advertises to clients;
-    # required is the subset clients must advertise back or be kicked.
+    # mandatory is the subset clients must advertise back or be kicked.
     # both default to empty so embedders/tests don't have to set them.
     available_proto_extensions: List[Tuple[int, int]] = []
-    required_proto_extensions: List[Tuple[int, int]] = []
+    mandatory_proto_extensions: List[Tuple[int, int]] = []
 
     def __init__(self, *arg, **kw):
         # +2 to allow server->master and master->server connection since enet

--- a/tests/pyspades/test_player.py
+++ b/tests/pyspades/test_player.py
@@ -15,7 +15,7 @@ class BaseConnectionTest(unittest.TestCase):
     def test_team_join(self):
         prot = Mock()
         prot.team_class = Team
-        prot.required_proto_extensions = []
+        prot.mandatory_proto_extensions = []
         server.ServerProtocol._create_teams(prot)
         # Some places still use the old name
         prot.players = {}

--- a/tests/pyspades/test_player.py
+++ b/tests/pyspades/test_player.py
@@ -15,6 +15,7 @@ class BaseConnectionTest(unittest.TestCase):
     def test_team_join(self):
         prot = Mock()
         prot.team_class = Team
+        prot.required_proto_extensions = []
         server.ServerProtocol._create_teams(prot)
         # Some places still use the old name
         prot.players = {}

--- a/tests/pyspades/test_player.py
+++ b/tests/pyspades/test_player.py
@@ -15,7 +15,8 @@ class BaseConnectionTest(unittest.TestCase):
     def test_team_join(self):
         prot = Mock()
         prot.team_class = Team
-        prot.mandatory_proto_extensions = []
+        prot.extensions.mandatory.return_value = []
+        prot.extensions.enabled_only.return_value = []
         server.ServerProtocol._create_teams(prot)
         # Some places still use the old name
         prot.players = {}

--- a/tests/pyspades/test_proto_extensions.py
+++ b/tests/pyspades/test_proto_extensions.py
@@ -1,0 +1,90 @@
+"""tests for pyspades/proto_extensions.py"""
+
+from twisted.trial import unittest
+
+from pyspades.constants import EXTENSION_CHATTYPE, EXTENSION_KICKREASON
+from pyspades.proto_extensions import (
+    DISABLED, ENABLED, MANDATORY,
+    ProtoExtensionPolicyConflict, ProtoExtensionRegistry,
+)
+
+
+class ProtoExtensionRegistryTest(unittest.TestCase):
+    def test_enable_then_reenable_updates_reason(self):
+        reg = ProtoExtensionRegistry()
+        reg.enable(EXTENSION_CHATTYPE, "first")
+        reg.enable(EXTENSION_CHATTYPE, "second", version=2)
+        policies = reg.policies()
+        self.assertEqual(policies[EXTENSION_CHATTYPE], (ENABLED, 2, "second"))
+
+    def test_enable_then_mandate_upgrades(self):
+        reg = ProtoExtensionRegistry()
+        reg.enable(EXTENSION_KICKREASON, "QoL")
+        reg.mandate(EXTENSION_KICKREASON, "competitive mode needs it")
+        self.assertEqual(reg.policy_of(EXTENSION_KICKREASON), MANDATORY)
+        mandatory = reg.mandatory()
+        self.assertEqual(len(mandatory), 1)
+        ext_id, ver, reason, name = mandatory[0]
+        self.assertEqual(ext_id, EXTENSION_KICKREASON)
+        self.assertEqual(reason, "competitive mode needs it")
+
+    def test_mandate_then_enable_stays_mandatory(self):
+        reg = ProtoExtensionRegistry()
+        reg.mandate(EXTENSION_KICKREASON, "strict policy")
+        reg.enable(EXTENSION_KICKREASON, "tried to weaken")
+        self.assertEqual(reg.policy_of(EXTENSION_KICKREASON), MANDATORY)
+        # mandate reason preserved, the later enable was discarded
+        ext_id, ver, reason, name = reg.mandatory()[0]
+        self.assertEqual(reason, "strict policy")
+
+    def test_mandate_then_mandate_updates_reason(self):
+        reg = ProtoExtensionRegistry()
+        reg.mandate(EXTENSION_KICKREASON, "first")
+        reg.mandate(EXTENSION_KICKREASON, "second")
+        ext_id, ver, reason, name = reg.mandatory()[0]
+        self.assertEqual(reason, "second")
+
+    def test_disable_after_enable_raises(self):
+        reg = ProtoExtensionRegistry()
+        reg.enable(EXTENSION_CHATTYPE, "QoL")
+        self.assertRaises(ProtoExtensionPolicyConflict,
+                          reg.disable, EXTENSION_CHATTYPE, "veto")
+
+    def test_disable_after_mandate_raises(self):
+        reg = ProtoExtensionRegistry()
+        reg.mandate(EXTENSION_KICKREASON, "needed")
+        self.assertRaises(ProtoExtensionPolicyConflict,
+                          reg.disable, EXTENSION_KICKREASON, "veto")
+
+    def test_enable_after_disable_raises(self):
+        reg = ProtoExtensionRegistry()
+        reg.disable(EXTENSION_CHATTYPE, "veto")
+        self.assertRaises(ProtoExtensionPolicyConflict,
+                          reg.enable, EXTENSION_CHATTYPE, "QoL")
+
+    def test_mandate_after_disable_raises(self):
+        reg = ProtoExtensionRegistry()
+        reg.disable(EXTENSION_KICKREASON, "veto")
+        self.assertRaises(ProtoExtensionPolicyConflict,
+                          reg.mandate, EXTENSION_KICKREASON, "needed")
+
+    def test_disable_idempotent(self):
+        reg = ProtoExtensionRegistry()
+        reg.disable(EXTENSION_CHATTYPE, "first reason")
+        reg.disable(EXTENSION_CHATTYPE, "second reason")
+        self.assertEqual(reg.policy_of(EXTENSION_CHATTYPE), DISABLED)
+
+    def test_advertised_lists_enabled_and_mandatory(self):
+        reg = ProtoExtensionRegistry()
+        reg.enable(EXTENSION_CHATTYPE, "QoL", version=1)
+        reg.mandate(EXTENSION_KICKREASON, "needed", version=2)
+        ids = sorted(ext_id for ext_id, _ in reg.advertised())
+        self.assertEqual(ids, sorted([EXTENSION_CHATTYPE,
+                                      EXTENSION_KICKREASON]))
+
+    def test_enabled_only_excludes_mandatory(self):
+        reg = ProtoExtensionRegistry()
+        reg.enable(EXTENSION_CHATTYPE, "QoL")
+        reg.mandate(EXTENSION_KICKREASON, "needed")
+        ids = [ext_id for ext_id, _, _, _ in reg.enabled_only()]
+        self.assertEqual(ids, [EXTENSION_CHATTYPE])


### PR DESCRIPTION
Adds required_proto_extensions on the protocol. Servers can list (extension_id, minimum_version) pairs that every client must advertise during the handshake — anyone missing one (or running too old a version) gets a chat error and is kicked before they can join.

⚠️ Clients not supporting a required extension and not supporting kick reason will be kicked without knowing why. This is the ugly part. A good thing would be to have the server list to know the server is requiring extension.

The check runs in two spots: as soon as the client's ProtocolExtensionInfo arrives (fast path for extension-aware clients), and again at ExistingPlayer time as a fallback for clients that never sent one (vanilla 0.75, older OpenSpades). Local connections are exempt.

Also lifts the long-standing skip of ProtocolExtensionInfo for OpenSpades ≤ 0.1.3 — but only when the server actually requires extensions, so those clients get the chance to advertise support before being judged.

Exposed via config.toml as required_proto_extensions = [[193, 1]]. Defaults to empty, behaviour is unchanged for everyone who doesn't opt in. The example in the shipped config is commented out.

Why
Right now extensions are just opportunistic — used for chat type colouring and not much else, so a "mandatory" knob isn't urgently needed.  Because as the protocol grows, extensions could start carrying actual gameplay-affecting features, servers will want a way to say "if your client doesn't speak X, you can't play here" without writing a custom script for it.


Note on testing
I'm on macOS arm64 and don't have a working build of any client old enough to be missing the extension protocol — vanilla 0.75 in particular. The "no ProtocolExtensionInfo ever arrives" path is therefore only verified by reading the code, not by actually connecting such a client. If anyone can spin up a vanilla 0.75 (or pre-extension OpenSpades) against this branch and confirm the kick fires at ExistingPlayer time as expected, I'd really appreciate it.


I do not know what you will think of it, let me know 😉 there are pros and cons.
For now people think more about using protocol extension vs new protocol version. so sooner or later there will be stuff affecting the gameplay coming out?

BTW, I can of course provide CI testing of it if you agree with the idea.