### PR TITLE
Readd togglevotekick as alias of /tvk

### DIFF
--- a/piqueserver/scripts/votekick.py
+++ b/piqueserver/scripts/votekick.py
@@ -151,7 +151,7 @@ def vote_yes(connection):
     votekick.vote(player)
 
 
-@command('tvk', admin_only=True)
+@command('tvk', 'togglevotekick', admin_only=True)
 def togglevotekick(connection, *args):
     """
     Toggles votekicking for a player or the whole server


### PR DESCRIPTION
Likely introduced by commit dabd947fa05cabc8565dadce602780b4b69c13e5.
Though it was the other way around by then; tvk as an alias to /togglevotekick.