### PR TITLE
Fix/818 game start event

### DIFF
--- a/doc/startup-and-initialization.rst
+++ b/doc/startup-and-initialization.rst
@@ -104,11 +104,28 @@ Games are defined by the game mode. They usually represent a period of time
 where two teams compete for points and end with one team winning or losing, or
 some other condition such as a time limit being hit.
 
-There is currently no hook for when the game starts. However, existing modes
-assume it starts with the ``on_map_change`` call.
+The protocol exposes two paired lifecycle hooks, ``on_game_start`` and
+``on_game_end``. Triggering goes through the guarded helpers
+``protocol.start_game()`` and ``protocol.end_game()``, which ensure each hook
+fires at most once per game — ``on_game_end`` will never be invoked twice for
+the same game, even if multiple end conditions race.
 
-When a game ends, the game mode will call ``on_game_end`` to notify any other
-scripts and possibly trigger a map change.
+``on_game_start`` is fired:
+
+- after a new map finishes loading (at the end of ``on_map_change``), even
+  when the map change was forced via ``/advancemap``, ``/loadmap``, or the
+  time limit expiring;
+- when a game ends on the current map and a new round begins without a map
+  change.
+
+``on_game_end`` is fired whenever the active game ends, so scripts can rely
+on it for cleanup or deallocation. It fires:
+
+- when the game mode signals that the current game has concluded (via
+  ``protocol.end_game()``), which may in turn trigger a map change;
+- when an advance is forced externally by the time limit expiring,
+  ``/advancemap``, or ``/loadmap`` — fired after the 10-second
+  countdown, just before the next map is loaded.
 
 Player Lifecycle
 ----------------

--- a/piqueserver/core_commands/game.py
+++ b/piqueserver/core_commands/game.py
@@ -37,7 +37,7 @@ def reset_game(connection):
         if resetting_player is connection:
             return
     connection.protocol.reset_game(resetting_player)
-    connection.protocol.on_game_end()
+    connection.protocol.end_game()
     connection.protocol.broadcast_chat(
         'Game has been reset by %s' % connection.name,
         irc=True)

--- a/piqueserver/game_modes/infiltration.py
+++ b/piqueserver/game_modes/infiltration.py
@@ -109,7 +109,7 @@ class DummyPlayer():
                 player.hp = None
                 if player.team is not None:
                     player.spawn()
-            self.protocol.on_game_end()
+            self.protocol.end_game()
         else:
             flag = self.team.other.set_flag()
             flag.update()

--- a/piqueserver/game_modes/tdm.py
+++ b/piqueserver/game_modes/tdm.py
@@ -134,13 +134,13 @@ def apply_script(protocol, connection, config):
                                      self.green_team.kills,
                                      self.blue_team.kills))
                 self.reset_game(player)
-                protocol.on_game_end(self)
+                self.end_game()
             elif self.blue_team.kills >= KILL_LIMIT.get():
                 self.broadcast_chat("%s Team Wins, %s - %s" %
                                     (self.blue_team.name,
                                      self.blue_team.kills,
                                      self.green_team.kills))
                 self.reset_game(player)
-                protocol.on_game_end(self)
+                self.end_game()
 
     return TDMProtocol, TDMConnection

--- a/piqueserver/server.py
+++ b/piqueserver/server.py
@@ -227,6 +227,7 @@ class FeatureProtocol(ServerProtocol):
     command_antispam = False
 
     planned_map = None
+    _advancing = False
 
     map_info = None
     spawns = None
@@ -523,6 +524,9 @@ class FeatureProtocol(ServerProtocol):
             self.planned_map = next(self.map_rotator)
         planned_map = self.planned_map
         self.planned_map = None
+        # Set _advancing up front so FeatureProtocol.on_game_end skips its
+        # own advance/restart branch when end_game() fires below.
+        self._advancing = True
         self.on_advance(planned_map)
 
         async def do_advance():
@@ -537,6 +541,10 @@ class FeatureProtocol(ServerProtocol):
                 log.info("advancing to map '{name}'",
                          name=planned_map.full_name)
 
+            # Fire on_game_end just before the map swap, so scripts that
+            # save final state or stop per-game loops see the actual end
+            # of the game rather than the start of the countdown.
+            self.end_game()
             await self.set_map_name(planned_map)
 
         return ensureDeferred(do_advance())
@@ -858,6 +866,10 @@ class FeatureProtocol(ServerProtocol):
     # events
 
     def on_map_change(self, the_map: VXLData) -> None:
+        # The next start_game must happen after the advance is finished,
+        # so clear the flag before any map hooks (or the start_game call
+        # below) run.
+        self._advancing = False
         self.set_fog_color(
             getattr(self.map_info.info, 'fog', self.default_fog)
         )
@@ -866,16 +878,27 @@ class FeatureProtocol(ServerProtocol):
         if map_on_map_change is not None:
             map_on_map_change(self, the_map)
 
+        self.start_game()
+
     def on_map_leave(self):
         map_on_map_leave = self.map_info.on_map_leave
         if map_on_map_leave is not None:
             map_on_map_leave(self)
 
     def on_game_end(self):
+        # advance_rotation already fired on_game_end and is taking care
+        # of loading the next map — don't kick off a second advance or
+        # restart the round in place.
+        if self._advancing:
+            return
+        advancing = False
         if self.advance_on_win <= 0:
             self.irc_say('Round ended!', me=True)
         elif next(self.win_count) % self.advance_on_win == 0:
             self.advance_rotation('Game finished!')
+            advancing = True
+        if not advancing:
+            self.start_game()
 
     def on_advance(self, map_name: str) -> None:
         pass

--- a/pyspades/entities.py
+++ b/pyspades/entities.py
@@ -123,7 +123,7 @@ class Territory(Flag):
         protocol.on_cp_capture(self)
         if team.score >= protocol.max_score:
             protocol.reset_game(territory=self)
-            protocol.on_game_end()
+            protocol.end_game()
         else:
             territory_capture.object_index = self.id
             territory_capture.state = self.team.id

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -916,7 +916,7 @@ class ServerConnection(BaseConnection):
         if (self.protocol.max_score not in (0, None) and
                 self.team.score >= self.protocol.max_score):
             self.protocol.reset_game(self)
-            self.protocol.on_game_end()
+            self.protocol.end_game()
         else:
             intel_capture = loaders.IntelCapture()
             intel_capture.player_id = self.player_id

--- a/pyspades/server.py
+++ b/pyspades/server.py
@@ -85,6 +85,7 @@ class ServerProtocol(BaseProtocol):
     version = GAME_VERSION
     respawn_waves = False
     master_hosts: List[MasterHostDict]
+    _game_active = False
 
     def __init__(self, *arg, **kw):
         # +2 to allow server->master and master->server connection since enet
@@ -495,6 +496,25 @@ class ServerProtocol(BaseProtocol):
 
     def on_game_end(self):
         pass
+
+    def on_game_start(self):
+        pass
+
+    def start_game(self):
+        """Trigger ``on_game_start``, guarded so it fires at most once
+        between ``end_game`` calls."""
+        if self._game_active:
+            return
+        self._game_active = True
+        self.on_game_start()
+
+    def end_game(self):
+        """Trigger ``on_game_end``, guarded so it fires at most once
+        per active game."""
+        if not self._game_active:
+            return
+        self._game_active = False
+        self.on_game_end()
 
     def on_world_update(self):
         pass

--- a/tests/piqueserver/test_server.py
+++ b/tests/piqueserver/test_server.py
@@ -2,10 +2,76 @@
 test piqueserver/server.py
 """
 
+from itertools import count
+
 from twisted.trial import unittest
+from unittest.mock import Mock
+
 import piqueserver.server
+from piqueserver.server import FeatureProtocol
 
 
 class TestServer(unittest.TestCase):
     def test_dummy(self):
         piqueserver.server
+
+
+class FeatureProtocolGameLifecycleTest(unittest.TestCase):
+    """``FeatureProtocol`` wires ``on_game_start`` into map changes, round
+    restarts, and externally-forced map advances (time-up, ``/advancemap``,
+    ``/loadmap``)."""
+
+    def _make_protocol(self, advance_on_win=0, game_active=False,
+                       advancing=False):
+        # Bypass __init__ — it touches the network, config, IRC, etc.
+        protocol = FeatureProtocol.__new__(FeatureProtocol)
+        protocol._game_active = game_active
+        protocol._advancing = advancing
+        protocol.on_game_start = Mock()
+        protocol.advance_on_win = advance_on_win
+        protocol.win_count = count(1)
+        protocol.advance_rotation = Mock()
+        protocol.irc_say = Mock()
+        protocol.set_fog_color = Mock()
+        protocol.default_fog = (0, 0, 0)
+        protocol.map_info = Mock()
+        protocol.map_info.on_map_change = None
+        protocol.map_info.on_map_leave = None
+        return protocol
+
+    def test_on_map_change_fires_on_game_start(self):
+        protocol = self._make_protocol()
+        protocol.on_map_change(Mock())
+        protocol.on_game_start.assert_called_once()
+        self.assertTrue(protocol._game_active)
+
+    def test_on_map_change_clears_advancing_flag(self):
+        protocol = self._make_protocol(advancing=True)
+        protocol.on_map_change(Mock())
+        self.assertFalse(protocol._advancing)
+
+    def test_on_game_end_bails_while_advancing(self):
+        # When advance_rotation has set _advancing=True before firing
+        # end_game(), the built-in advance/restart logic must not run —
+        # otherwise it would race the in-flight map change.
+        protocol = self._make_protocol(advance_on_win=1, game_active=True,
+                                       advancing=True)
+        FeatureProtocol.on_game_end(protocol)
+        protocol.advance_rotation.assert_not_called()
+        protocol.on_game_start.assert_not_called()
+
+    def test_on_game_end_starts_next_round_on_same_map(self):
+        # advance_on_win=0 → round restarts in place, no map advance.
+        protocol = self._make_protocol(advance_on_win=0)
+        FeatureProtocol.on_game_end(protocol)
+        protocol.advance_rotation.assert_not_called()
+        protocol.on_game_start.assert_called_once()
+        self.assertTrue(protocol._game_active)
+
+    def test_on_game_end_advances_without_restarting_in_place(self):
+        # advance_on_win=1 → every game advances; the new map's on_map_change
+        # is responsible for on_game_start, not on_game_end.
+        protocol = self._make_protocol(advance_on_win=1)
+        FeatureProtocol.on_game_end(protocol)
+        protocol.advance_rotation.assert_called_once()
+        protocol.on_game_start.assert_not_called()

--- a/tests/pyspades/test_server.py
+++ b/tests/pyspades/test_server.py
@@ -3,8 +3,54 @@ test pyspades/server.py
 """
 
 from twisted.trial import unittest
+from unittest.mock import Mock
 from pyspades import server
+from pyspades.server import ServerProtocol
+
 
 class BaseConnectionTest(unittest.TestCase):
     def test_test(self):
         pass
+
+
+class GameLifecycleTest(unittest.TestCase):
+    """``start_game`` / ``end_game`` are guarded by ``_game_active`` so each
+    hook fires at most once per transition."""
+
+    def _make_protocol(self):
+        # Bypass __init__ (which opens an enet socket).
+        protocol = ServerProtocol.__new__(ServerProtocol)
+        protocol._game_active = False
+        protocol.on_game_start = Mock()
+        protocol.on_game_end = Mock()
+        return protocol
+
+    def test_start_fires_once_until_end(self):
+        protocol = self._make_protocol()
+        protocol.start_game()
+        protocol.start_game()
+        self.assertEqual(protocol.on_game_start.call_count, 1)
+        self.assertTrue(protocol._game_active)
+
+    def test_end_without_start_is_noop(self):
+        protocol = self._make_protocol()
+        protocol.end_game()
+        protocol.on_game_end.assert_not_called()
+        self.assertFalse(protocol._game_active)
+
+    def test_end_fires_once_until_start(self):
+        protocol = self._make_protocol()
+        protocol.start_game()
+        protocol.end_game()
+        protocol.end_game()
+        self.assertEqual(protocol.on_game_end.call_count, 1)
+        self.assertFalse(protocol._game_active)
+
+    def test_full_cycle(self):
+        protocol = self._make_protocol()
+        protocol.start_game()
+        protocol.end_game()
+        protocol.start_game()
+        protocol.end_game()
+        self.assertEqual(protocol.on_game_start.call_count, 2)
+        self.assertEqual(protocol.on_game_end.call_count, 2)


### PR DESCRIPTION
Closes #818.

- `on_game_start()` stub on `ServerProtocol`, plus `start_game()` / `end_game()` helpers guarded by a `_game_active` flag so each hook fires at most once per game transition. Calling `start_game()` twice in a row, or `end_game()` without a matching start, are no-ops — no double-firing if multiple end conditions race.
- Every existing in-tree caller (`/resetgame`, TDM kill limit, infiltration, intel/territory captures) now goes through `end_game()` rather than poking `on_game_end()` directly, so the guard sees every transition.
- `FeatureProtocol.on_map_change` fires `start_game()` at the end, after the map's own `on_map_change` callback has run.
- `FeatureProtocol.on_game_end` fires `start_game()` when a round restarts on the same map (no advance).
- `advance_rotation` sets an `_advancing` flag up front and calls `end_game()` from inside `do_advance`, **after** the 10-second countdown and right before `set_map_name`. So `on_game_end` lines up with the actual end of the game visually, not the moment the countdown begins. `FeatureProtocol.on_game_end` bails when `_advancing` is set to avoid recursing back through the `advance_on_win` branch.

Heads up: small TDM behaviour change

The old TDM code called `protocol.on_game_end(self)` where `protocol` was the `apply_script` argument — i.e. the parent class, not the MRO. That meant TDM **bypassed any other script's `on_game_end` override stacked on top of it**. So e.g. running `rollback` on a TDM server with `rollback_on_game_end = true` would *not* actually roll back on kill-limit wins. Switching to `self.end_game()` walks the full MRO and fixes that. Almost certainly what was always intended, but worth flagging because it does change live behaviour for anyone running TDM under another script.

Migration note... Compatibility break?

If your script currently calls `protocol.on_game_end()` to *trigger* end-of-game (rather than chaining from inside an override), switch the call to `protocol.end_game()` — otherwise you bypass the new guard and can double-fire the hook. Scripts that just chain via `protocol.on_game_end(self)` from inside their own `on_game_end` override don't need any change.

Feel free to let me know what changes are needed ;) I really hope I didn't miss anything !
