### PR TITLE
Add support for the Player Properties extension.

### DIFF
--- a/piqueserver/server.py
+++ b/piqueserver/server.py
@@ -57,7 +57,8 @@ from piqueserver.utils import as_deferred, EndCall
 from piqueserver.bansubscribe import bans_config_urls
 from pyspades.bytes import NoDataLeft
 from pyspades.constants import (CTF_MODE, ERROR_SHUTDOWN, TC_MODE,
-                                EXTENSION_CHATTYPE, EXTENSION_KICKREASON)
+                                EXTENSION_CHATTYPE, EXTENSION_KICKREASON,
+                                EXTENSION_PLAYERPROPERTIES)
 from pyspades.master import MAX_SERVER_NAME_SIZE
 from pyspades.server import ServerProtocol, Team
 from pyspades.tools import make_server_identifier
@@ -277,6 +278,7 @@ class FeatureProtocol(ServerProtocol):
         self.bans = NetworkDict()
 
         self.available_proto_extensions = [
+            (EXTENSION_PLAYERPROPERTIES, 1),
             (EXTENSION_CHATTYPE, 1),
             (EXTENSION_KICKREASON, 1),
         ]

--- a/pyspades/constants.py
+++ b/pyspades/constants.py
@@ -74,15 +74,14 @@ ERROR_SHUTDOWN = 5
 ERROR_KICKED = 10
 ERROR_INVALID_NAME = 20
 
+# Base packet id for protocol-extension packets. Each extension's
+# packet id is PACKET_EXT_BASE + ext_id.
+PACKET_EXT_BASE = 0x40
+
 EXTENSION_PLAYERPROPERTIES = 0
 EXTENSION_PLAYERLIMIT = 192
 EXTENSION_CHATTYPE = 193
 EXTENSION_KICKREASON = 194
-
-# Sub-ids for the Player Properties extension (packet id 64). Sub id 0 is
-# the only one currently defined; preserved on the wire so future sub-ids
-# can be dispatched by callers.
-PLAYERPROPERTIES_SUB_QUERY = 0
 
 CTF_MODE = 0
 TC_MODE = 1

--- a/pyspades/constants.py
+++ b/pyspades/constants.py
@@ -74,9 +74,15 @@ ERROR_SHUTDOWN = 5
 ERROR_KICKED = 10
 ERROR_INVALID_NAME = 20
 
+EXTENSION_PLAYERPROPERTIES = 0
 EXTENSION_PLAYERLIMIT = 192
 EXTENSION_CHATTYPE = 193
 EXTENSION_KICKREASON = 194
+
+# Sub-ids for the Player Properties extension (packet id 64). Sub id 0 is
+# the only one currently defined; preserved on the wire so future sub-ids
+# can be dispatched by callers.
+PLAYERPROPERTIES_SUB_QUERY = 0
 
 CTF_MODE = 0
 TC_MODE = 1

--- a/pyspades/contained.pyx
+++ b/pyspades/contained.pyx
@@ -991,3 +991,43 @@ cdef class ProtocolExtensionInfo(Loader):
             writer.writeByte(ext[1])
 
 register_packet(ProtocolExtensionInfo)
+
+
+cdef class PacketPlayerProperties(Loader):
+    """Player Properties protocol extension (id 0).
+
+    Server-to-client packet carrying authoritative per-player stats
+    (HP, ammo, blocks, grenades, score). Sub-packet id 0 is the only
+    currently defined sub-type; the byte is preserved on read/write so
+    future sub-types can be dispatched by callers.
+    """
+    id = 64
+
+    cdef public:
+        unsigned int sub_id
+        unsigned int player_id, hp, blocks, grenades
+        unsigned int magazine_ammo, reserve_ammo
+        unsigned int score
+
+    cpdef read(self, ByteReader reader):
+        self.sub_id = reader.readByte(True)
+        self.player_id = reader.readByte(True)
+        self.hp = reader.readByte(True)
+        self.blocks = reader.readByte(True)
+        self.grenades = reader.readByte(True)
+        self.magazine_ammo = reader.readByte(True)
+        self.reserve_ammo = reader.readByte(True)
+        self.score = reader.readInt(True, False)
+
+    cpdef write(self, ByteWriter writer):
+        writer.writeByte(self.id, True)
+        writer.writeByte(self.sub_id, True)
+        writer.writeByte(self.player_id, True)
+        writer.writeByte(self.hp, True)
+        writer.writeByte(self.blocks, True)
+        writer.writeByte(self.grenades, True)
+        writer.writeByte(self.magazine_ammo, True)
+        writer.writeByte(self.reserve_ammo, True)
+        writer.writeInt(self.score, True, False)
+
+register_packet(PacketPlayerProperties, client=False)

--- a/pyspades/contained.pyx
+++ b/pyspades/contained.pyx
@@ -28,7 +28,7 @@ This module contains the definitions and registrations for the various packets u
 # speed up allocation for packets
 
 from pyspades.common import encode, decode
-from pyspades.constants import NEUTRAL_TEAM, CTF_MODE, TC_MODE
+from pyspades.constants import NEUTRAL_TEAM, CTF_MODE, TC_MODE, PACKET_EXT_BASE
 from pyspades.loaders cimport Loader
 from pyspades.bytes cimport ByteReader, ByteWriter
 from pyspades.packet import register_packet
@@ -993,15 +993,17 @@ cdef class ProtocolExtensionInfo(Loader):
 register_packet(ProtocolExtensionInfo)
 
 
-cdef class PacketPlayerProperties(Loader):
-    """Player Properties protocol extension (id 0).
+cdef class PlayerPropertiesV1(Loader):
+    """Player Properties protocol extension (id 0, v1).
 
     Server-to-client packet carrying authoritative per-player stats
     (HP, ammo, blocks, grenades, score). Sub-packet id 0 is the only
     currently defined sub-type; the byte is preserved on read/write so
     future sub-types can be dispatched by callers.
     """
-    id = 64
+    ext_id = 0
+    ext_version = 1
+    id = PACKET_EXT_BASE + ext_id
 
     cdef public:
         unsigned int sub_id
@@ -1030,4 +1032,4 @@ cdef class PacketPlayerProperties(Loader):
         writer.writeByte(self.reserve_ammo, True)
         writer.writeInt(self.score, True, False)
 
-register_packet(PacketPlayerProperties, client=False)
+register_packet(PlayerPropertiesV1, client=False)

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -1365,8 +1365,8 @@ class ServerConnection(BaseConnection):
         if explicit_score:
             self.kills = score
 
-        packet = loaders.PacketPlayerProperties()
-        packet.sub_id = PLAYERPROPERTIES_SUB_QUERY
+        packet = loaders.PlayerPropertiesV1()
+        packet.sub_id = 0
         packet.player_id = self.player_id
         packet.hp = hp
         packet.blocks = blocks

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -1377,6 +1377,41 @@ class ServerConnection(BaseConnection):
         self.send_contained(packet)
         return True
 
+    def broadcast_player_properties(self) -> bool:
+        """Broadcast this player's authoritative Player Properties
+        (extension 0) packet to every connected player that has
+        negotiated the extension, including this player.
+
+        Useful for keeping clients in sync with server state when their
+        local estimates would otherwise diverge -- notably BetterSpades,
+        which estimates other players' ammo and silently stops them
+        shooting at its guessed zero.
+
+        Values are read from current server-side state; nothing is
+        persisted or overridden. ``hp`` falls back to 0 when the player
+        is dead. Returns False if the player has no id yet or hasn't
+        fully joined (no weapon, blocks or grenades state).
+        """
+        if self.player_id is None:
+            return False
+        if (self.blocks is None or self.grenades is None
+                or self.weapon_object is None):
+            return False
+        packet = loaders.PlayerPropertiesV1()
+        packet.sub_id = 0
+        packet.player_id = self.player_id
+        packet.hp = 0 if self.hp is None else self.hp
+        packet.blocks = self.blocks
+        packet.grenades = self.grenades
+        packet.magazine_ammo = self.weapon_object.current_ammo
+        packet.reserve_ammo = self.weapon_object.current_stock
+        packet.score = self.kills
+        self.protocol.broadcast_contained(
+            packet,
+            rule=lambda p: EXTENSION_PLAYERPROPERTIES in p.proto_extensions,
+        )
+        return True
+
     def send_chat(self, value: str, global_message: bool = False, custom_type: int = CHAT_ALL) -> None:
         if self.deaf:
             return

--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -1265,6 +1265,118 @@ class ServerConnection(BaseConnection):
         msg.value = reason[:MAX_CHAT_SIZE]
         self.send_contained(msg)
 
+    def send_player_properties(
+        self,
+        *,
+        hp: Optional[int] = None,
+        blocks: Optional[int] = None,
+        grenades: Optional[int] = None,
+        magazine_ammo: Optional[int] = None,
+        reserve_ammo: Optional[int] = None,
+        score: Optional[int] = None,
+    ) -> bool:
+        """Send this client an authoritative Player Properties (extension 0)
+        packet about itself, and persist any explicit overrides to the
+        player's server-side state.
+
+        Stats such as magazine/reserve ammo, blocks and grenades are private
+        per-player in AoS, so this helper only ever sends a player their own
+        properties.
+
+        Each field may be overridden via the matching keyword argument; any
+        field left as None is taken from the player's current state. If the
+        server has no current value (e.g. hp before spawn, ammo with no
+        weapon), the matching argument becomes mandatory and ValueError is
+        raised when omitted. Values outside the wire range (0..255 for
+        bytes, 0..2**32-1 for score) also raise ValueError.
+
+        Explicit overrides are written back to the player's server-side
+        attributes (``self.hp``, ``self.blocks``, ``self.grenades``,
+        ``self.weapon_object.current_ammo`` / ``.current_stock``,
+        ``self.kills``) so subsequent packets and snapshots reflect the
+        new values. Ammo overrides are only persisted when the player has
+        a weapon_object; without one, the wire emission still happens but
+        no server state can be updated for those fields.
+
+        Returns False if the client did not negotiate the extension or the
+        player has no id yet (handshake not complete).
+        """
+        if EXTENSION_PLAYERPROPERTIES not in self.proto_extensions:
+            return False
+        if self.player_id is None:
+            return False
+
+        explicit_hp = hp is not None
+        explicit_blocks = blocks is not None
+        explicit_grenades = grenades is not None
+        explicit_magazine = magazine_ammo is not None
+        explicit_reserve = reserve_ammo is not None
+        explicit_score = score is not None
+
+        if hp is None:
+            if self.hp is None:
+                raise ValueError(
+                    "hp must be provided: player has no current hp")
+            hp = self.hp
+        if blocks is None:
+            if self.blocks is None:
+                raise ValueError(
+                    "blocks must be provided: player has no current blocks")
+            blocks = self.blocks
+        if grenades is None:
+            if self.grenades is None:
+                raise ValueError(
+                    "grenades must be provided: player has no current grenades")
+            grenades = self.grenades
+        if magazine_ammo is None:
+            if self.weapon_object is None:
+                raise ValueError(
+                    "magazine_ammo must be provided: player has no weapon")
+            magazine_ammo = self.weapon_object.current_ammo
+        if reserve_ammo is None:
+            if self.weapon_object is None:
+                raise ValueError(
+                    "reserve_ammo must be provided: player has no weapon")
+            reserve_ammo = self.weapon_object.current_stock
+        if score is None:
+            score = self.kills
+
+        for name, value in (("hp", hp), ("blocks", blocks),
+                            ("grenades", grenades),
+                            ("magazine_ammo", magazine_ammo),
+                            ("reserve_ammo", reserve_ammo)):
+            if not 0 <= value <= 255:
+                raise ValueError(
+                    "{}={} out of range 0..255".format(name, value))
+        if not 0 <= score <= 0xFFFFFFFF:
+            raise ValueError(
+                "score={} out of range 0..2**32-1".format(score))
+
+        if explicit_hp:
+            self.hp = hp
+        if explicit_blocks:
+            self.blocks = blocks
+        if explicit_grenades:
+            self.grenades = grenades
+        if explicit_magazine and self.weapon_object is not None:
+            self.weapon_object.current_ammo = magazine_ammo
+        if explicit_reserve and self.weapon_object is not None:
+            self.weapon_object.current_stock = reserve_ammo
+        if explicit_score:
+            self.kills = score
+
+        packet = loaders.PacketPlayerProperties()
+        packet.sub_id = PLAYERPROPERTIES_SUB_QUERY
+        packet.player_id = self.player_id
+        packet.hp = hp
+        packet.blocks = blocks
+        packet.grenades = grenades
+        packet.magazine_ammo = magazine_ammo
+        packet.reserve_ammo = reserve_ammo
+        packet.score = score
+        self.send_contained(packet)
+        return True
+
     def send_chat(self, value: str, global_message: bool = False, custom_type: int = CHAT_ALL) -> None:
         if self.deaf:
             return


### PR DESCRIPTION
This PR is needed to have pique comply with existing protocol extension (There is still utf-8 extension missing to my knowledge).

The spec of this extension is not from me but in [my ongoing PR ](https://github.com/piqueserver/aosprotocol/pull/54) I am documenting it. Be aware that zerospades already supported it (with [an issue ](https://github.com/zerospades/zerospades/pull/35)about score I discovered while testing this PR )for a long time, as well as better spades and libspades.

The server does not need it nor use it to run. The extension is available for game mode to use if needed.

Worth noting that my PR does not allow sending the data of a player to another player. As to my knowledge, clients are not aware of other player's hp/ammo... Somehow score would make sense but that should be for an hypothetic future sub packet id ?