### PR TITLE
Handle exception on world.update call in server.py

### DIFF
--- a/pyspades/server.py
+++ b/pyspades/server.py
@@ -252,8 +252,8 @@ class ServerProtocol(BaseProtocol):
             # Update world
             while (time.monotonic() - self.world_time) > UPDATE_FREQUENCY:
                 self.loop_count += 1
-                self.world.update(UPDATE_FREQUENCY)
                 try:
+                    self.world.update(UPDATE_FREQUENCY)
                     self.on_world_update()
                 except Exception:
                     traceback.print_exc()


### PR DESCRIPTION
Unauthenticated clients can crash the game update loop by causing player state to become partially initialized, then triggering a later world callback that assumes the missing state exists. I have verified this issue by running the server and running the PoC script against it.

Root cause:
A malformed join sequence can register a player before weapon initialization completes, leaving weapon_object=None. Later, normal respawn/world logic treats the player as alive and eventually calls code that dereferences weapon_object.

Impact:
The exception occurs during world.update(), which is outside the local exception handler, so the async game update loop stops servicing clients.

PoC:
Run the included PoC script to reproduce the crash.

[poc_invalid_weapon_crash.py](https://github.com/user-attachments/files/29813284/poc_invalid_weapon_crash.py)